### PR TITLE
feat(model): close ModelWriter trait abstraction follow-up (lifecycle + skip log + record key + drain-only baseline)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,8 +257,8 @@ dependencies = [
  "simplelog",
  "smol_str 0.3.6",
  "strum 0.27.2",
- "surrealdb 3.1.0-alpha (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "surrealdb-types 3.1.0-alpha (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
+ "surrealdb",
+ "surrealdb-types",
  "sysinfo 0.37.2",
  "tempfile",
  "thiserror 1.0.69",
@@ -308,7 +308,7 @@ dependencies = [
  "gltf",
  "hash32 1.0.0",
  "hexasphere",
- "id_tree 1.8.0",
+ "id_tree 1.8.0 (git+https://github.com/happyrust/id_tree)",
  "indexmap 2.13.0",
  "indextree",
  "itertools 0.14.0",
@@ -346,8 +346,8 @@ dependencies = [
  "spade",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "surrealdb 3.1.0-alpha (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
- "surrealdb-types 3.1.0-alpha (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
+ "surrealdb",
+ "surrealdb-types",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.23",
@@ -1900,6 +1900,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 [[package]]
 name = "calamine"
 version = "0.26.1"
+source = "git+https://github.com/happyrust/calamine#f35ae176fa9f763851b236f7166e38a884efc8d6"
 dependencies = [
  "atoi_simd",
  "byteorder",
@@ -1992,6 +1993,7 @@ dependencies = [
 [[package]]
 name = "cavalier_contours"
 version = "0.4.0"
+source = "git+https://github.com/happyrust/cavalier_contours#d2d0db137836b672bf7493c047425a146aeb9266"
 dependencies = [
  "num-traits",
  "serde",
@@ -5716,6 +5718,8 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 [[package]]
 name = "id_tree"
 version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd9db8dd5be8bde5a2624ed4b2dfb74368fe7999eb9c4940fd3ca344b61071a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5725,8 +5729,7 @@ dependencies = [
 [[package]]
 name = "id_tree"
 version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd9db8dd5be8bde5a2624ed4b2dfb74368fe7999eb9c4940fd3ca344b61071a"
+source = "git+https://github.com/happyrust/id_tree#483f2ec03fc107b9195a8c2be6dec5532891b507"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5832,6 +5835,7 @@ dependencies = [
 [[package]]
 name = "indextree"
 version = "4.7.4"
+source = "git+https://github.com/happyrust/indextree?branch=main#2416dca00df8f928a6fee492702cb5224482a4ba"
 dependencies = [
  "indextree-macros",
  "rkyv 0.8.15",
@@ -5840,6 +5844,7 @@ dependencies = [
 [[package]]
 name = "indextree-macros"
 version = "0.1.3"
+source = "git+https://github.com/happyrust/indextree?branch=main#2416dca00df8f928a6fee492702cb5224482a4ba"
 dependencies = [
  "either",
  "itertools 0.14.0",
@@ -6787,6 +6792,7 @@ dependencies = [
 [[package]]
 name = "miniacd"
 version = "0.1.3"
+source = "git+https://github.com/happyrust/miniacd-fork.git?branch=main#89bc858829e77529772ad82a46f011a8f4f9d7fa"
 dependencies = [
  "ahash 0.8.12",
  "glamx",
@@ -10533,6 +10539,7 @@ dependencies = [
 [[package]]
 name = "rvm-rs"
 version = "0.1.0"
+source = "git+https://github.com/happyrust/rvm-rs#45470d2a0ddcabcd1f11958362e6440865bfc24e"
 dependencies = [
  "glam 0.30.10",
  "memmap2",
@@ -11508,40 +11515,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "surrealdb"
 version = "3.1.0-alpha"
-dependencies = [
- "anyhow",
- "async-channel 2.5.0",
- "boxcar",
- "chrono",
- "futures",
- "getrandom 0.3.4",
- "indexmap 2.13.0",
- "js-sys",
- "path-clean",
- "ring",
- "rustls-pki-types",
- "semver",
- "serde",
- "serde_json",
- "surrealdb-core 3.1.0-alpha (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "surrealdb-types 3.1.0-alpha (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "surrealdb-types-derive 3.1.0-alpha (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "tokio",
- "tokio-tungstenite",
- "tokio-tungstenite-wasm",
- "tokio-util",
- "tracing",
- "url",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasmtimer",
- "web-sys",
-]
-
-[[package]]
-name = "surrealdb"
-version = "3.1.0-alpha"
 source = "git+https://github.com/happyrust/surrealdb?branch=dev-3.1#9ab864392bd5a49c5d05da3528d5c9890d2126f9"
 dependencies = [
  "anyhow",
@@ -11558,9 +11531,9 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "surrealdb-core 3.1.0-alpha (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
- "surrealdb-types 3.1.0-alpha (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
- "surrealdb-types-derive 3.1.0-alpha (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
+ "surrealdb-core",
+ "surrealdb-types",
+ "surrealdb-types-derive",
  "tokio",
  "tokio-tungstenite",
  "tokio-tungstenite-wasm",
@@ -11572,95 +11545,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasmtimer",
  "web-sys",
-]
-
-[[package]]
-name = "surrealdb-core"
-version = "3.1.0-alpha"
-dependencies = [
- "addr",
- "affinitypool",
- "ahash 0.8.12",
- "ammonia",
- "anyhow",
- "argon2",
- "async-channel 2.5.0",
- "async-stream",
- "async-trait",
- "base64 0.22.1",
- "bcrypt",
- "blake3",
- "bytes",
- "chrono",
- "ciborium",
- "dashmap 6.1.0",
- "deunicode",
- "dmp",
- "ext-sort",
- "fastnum",
- "fst",
- "futures",
- "fuzzy-matcher",
- "geo 0.32.0",
- "geo-types",
- "getrandom 0.3.4",
- "headers",
- "hex",
- "http",
- "humantime",
- "ipnet",
- "jsonwebtoken 10.3.0",
- "lexicmp",
- "md-5",
- "mime",
- "ndarray",
- "ndarray-stats",
- "num-traits",
- "num_cpus",
- "object_store",
- "parking_lot",
- "path-clean",
- "pbkdf2",
- "phf 0.13.1",
- "pin-project-lite",
- "quick_cache",
- "radix_trie",
- "rand 0.8.5",
- "rayon",
- "reblessive",
- "regex",
- "revision",
- "ring",
- "roaring",
- "rust-stemmers",
- "rust_decimal",
- "scrypt",
- "semver",
- "serde",
- "serde_json",
- "sha1",
- "sha2",
- "storekey",
- "strsim 0.11.1",
- "subtle",
- "surrealdb-protocol 0.7.0 (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "surrealdb-rocksdb",
- "surrealdb-types 3.1.0-alpha (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "surrealmx",
- "sysinfo 0.37.2",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "ulid",
- "unicase",
- "url",
- "uuid",
- "vart",
- "wasm-bindgen-futures",
- "wasmtimer",
- "web-time",
 ]
 
 [[package]]
@@ -11733,9 +11617,9 @@ dependencies = [
  "storekey",
  "strsim 0.11.1",
  "subtle",
- "surrealdb-protocol 0.7.0 (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
+ "surrealdb-protocol",
  "surrealdb-rocksdb",
- "surrealdb-types 3.1.0-alpha (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
+ "surrealdb-types",
  "surrealmx",
  "sysinfo 0.37.2",
  "tempfile",
@@ -11766,29 +11650,6 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "zstd-sys",
-]
-
-[[package]]
-name = "surrealdb-protocol"
-version = "0.7.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "flatbuffers",
- "futures",
- "geo 0.31.0",
- "http-body-util",
- "prost",
- "prost-types",
- "rust_decimal",
- "semver",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
- "uuid",
 ]
 
 [[package]]
@@ -11828,32 +11689,6 @@ dependencies = [
 [[package]]
 name = "surrealdb-types"
 version = "3.1.0-alpha"
-dependencies = [
- "anyhow",
- "bytes",
- "castaway",
- "chrono",
- "flatbuffers",
- "geo 0.32.0",
- "hex",
- "http",
- "papaya",
- "rand 0.8.5",
- "regex",
- "rstest",
- "rust_decimal",
- "serde",
- "serde_json",
- "surrealdb-protocol 0.7.0 (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "surrealdb-types-derive 3.1.0-alpha (git+https://gitee.com/happydpc/surrealdb?branch=dev-3.1)",
- "tracing",
- "ulid",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-types"
-version = "3.1.0-alpha"
 source = "git+https://github.com/happyrust/surrealdb?branch=dev-3.1#9ab864392bd5a49c5d05da3528d5c9890d2126f9"
 dependencies = [
  "anyhow",
@@ -11870,19 +11705,10 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "surrealdb-protocol 0.7.0 (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
- "surrealdb-types-derive 3.1.0-alpha (git+https://github.com/happyrust/surrealdb?branch=dev-3.1)",
+ "surrealdb-protocol",
+ "surrealdb-types-derive",
  "ulid",
  "uuid",
-]
-
-[[package]]
-name = "surrealdb-types-derive"
-version = "3.1.0-alpha"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,6 @@ manifold = ["aios_core/manifold"]
 # debug_parse = ["pdms_io/debug_parse"]  # 暂时禁用以避免冲突
 surreal-save = []
 write-to-surrealdb = []
-model-writer-drain = []
 # Mock backend：仅供 trait 契约验证 binary 使用，不进 release。
 model-writer-mock = []
 test = ["aios_core/test"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ path = "src/bin/web_server.rs"
 required-features = ["web_server"]
 
 [[bin]]
+name = "verify_model_writer_trait"
+path = "src/bin/verify_model_writer_trait.rs"
+required-features = ["model-writer-mock"]
+
+[[bin]]
 name = "aios-database"
 path = "src/main.rs"
 # `cargo test` 默认会为 bin 也构建 `--test` harness；该工程 bin 依赖重且在 Windows 下易引发链接/内存异常。
@@ -244,6 +249,8 @@ manifold = ["aios_core/manifold"]
 surreal-save = []
 write-to-surrealdb = []
 model-writer-drain = []
+# Mock backend：仅供 trait 契约验证 binary 使用，不进 release。
+model-writer-mock = []
 test = ["aios_core/test"]
 mem-kv-save = ["aios_core/mem-kv-save"] #额外保存PE数据到内存KV数据库
 kv-rocksdb = [

--- a/docs/plans/2026-05-09-model-write-trait-followup/findings.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/findings.md
@@ -202,7 +202,7 @@ hot path 上每个 batch 都过 `Pin<Box<dyn Future>>`，nightly 已支持原生
 
 #### N4. `name()` 仅在 `finalize` 用一次
 
-可改为 `const NAME: &'static str`，让实现自存常量。**对应 Task**：T5.2。
+可改为 `const NAME: &'static str`，让实现自存常量。**对应 Task**：~~T5.2~~（**Skipped 2026-05-11**：trait 通过 `Arc<dyn ModelWriterBackend>` 走 vtable 调用，关联 const 不进 vtable，调不到。method 形式必须保留；保留 fn 形式 + const 双轨纯粹冗余。）
 
 #### N5. SQL 拼接缺显式 sanitize 层
 
@@ -227,8 +227,11 @@ let report = pdms_inst::save_instance_data_with_report(..., &mesh_results, ...).
 |---|---|---|
 | `RecordingBackend` 是否进 release 编译？ | (a) `#[cfg(test)]`<br>(b) feature flag `model-writer-mock` | **b**：方便用 binary 验证而不需 cargo test |
 | trait 命名最终值 | (a) `ModelWriterBackend`<br>(b) `ModelWriter`<br>(c) 保持 `ModelWriteBackend` | **a**：与 `ModelWriterMode` 对齐 |
-| DrainOnly 是否完全删除独立的 `run_drain_only_sink`？ | (a) 删，逻辑搬进 backend<br>(b) 保留，作为 backend 内部子流程 | **a**：彻底统一 |
+| DrainOnly 是否完全删除独立的 `run_drain_only_sink`？ | (a) 删，逻辑搬进 backend<br>(b) 保留，作为 backend 内部子流程 | **~~a~~ b**（2026-05-11 修订，详见下条 DrainOnly baseline 用途） |
 | `BooleanBridgeRequest::db_option` 是否也精简掉？ | (a) 保留，因为 boolean worker 真要用 DbOption<br>(b) 改为 trait method 注入更小的 BridgeContext | T3.2 配套讨论，倾向 **a**（短期保留） |
+| DrainOnly 快速路径去留？（2026-05-11 二期审核新增） | (a) 删快速路径让主管线统一跑<br>(b) 保留快速路径 + 锁死 trait 中间方法不被路由 | **b**（2026-05-11 用户拍板）：DrainOnly 的用途是「跳过所有持久化、仅跑生产端与调度，作为 baseline 对比不同 backend 的 IO 写入耗时」。删快速路径会让 baseline 包含 mesh/aabb 调度开销，失去对比意义。代码侧通过 module doc + 函数体 invariant 注释锁定语义 |
+| `WriteBaseReport.missing_neg_carriers` 是否拆为独立 trait 方法？（2026-05-11 二期审核新增） | (a) 现状保留 + 仅删 `#[non_exhaustive]` 噪声<br>(b) 拆 `take_missing_neg_carriers()` trait method | **a** 短期（本 PR 范围），**b** 移到 Phase 5 backlog（侵入面大于本 PR 收益） |
+| `parquet.rs` 是否进 trait 工厂？（2026-05-11 二期审核新增） | (a) 现状文件 sink，不实现 trait<br>(b) 实现 trait + 加入 `create_model_writer` 工厂 | **a** 短期：与 docs/development/model-writer-storage Phase 1 共识一致，本轮只加位置说明，**b** 留 Phase 5 |
 
 ## 4. 新增发现（开干后追加）
 

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -259,8 +259,8 @@
 | C | C.2 Factory + DbOption + CLI 接入 | complete | 2026-05-12 | commit `fb79afa8`，`model_writer_compare_with: Option<ModelWriterMode>`，validate 2c 守卫（拒 self-compare / drain-only / missing output_root），`--model-writer-compare-with` CLI |
 | C | C.3 Verify binary compare 路径 | complete | 2026-05-12 | commit `3300ed7d`，exit code 7 = compare wrapper fail；primary (mock) snapshot 校验 + candidate (parquet) 13 表落盘断言 |
 | C | C 阶段 PR | complete | 2026-05-12 | PR #15: https://github.com/happyrust/plant-model-gen/pull/15 （base = Phase B 分支，stack PR） |
-| D | D.1 DuckLakeModelWriterBackend 骨架 | pending | — | feature `ducklake` 守门 |
-| D | D.2 D 阶段 PR | pending | — | — |
+| D | D.1 DuckLakeModelWriterBackend 骨架 | complete | 2026-05-12 | commit `88071608`，feature `ducklake = []`，trait 8 方法全 `bail!`，工厂 cfg 守门；ModelWriterMode::DuckLake + parse + validate 守卫 |
+| D | D.2 D 阶段 PR | complete | 2026-05-12 | PR #16: https://github.com/happyrust/plant-model-gen/pull/16；`cargo check --features review` + `cargo check --features review,ducklake` 均 PASS |
 | E | E.1 validate-model-writer CLI umbrella | pending | — | — |
 | E | E.2 SQL parity scripts | pending | — | 13 张 Phase 1 表 × 2 个 SQL |
 | E | E.3 E 阶段 PR | pending | — | — |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -255,9 +255,10 @@
 | B | B.2 接入 create_model_writer 工厂 | complete | 2026-05-12 | commit `0d91b496`，ModelWriterMode::Parquet + DbOptionExt 字段 + validate 守卫 + CLI flags `--parquet-output-root` / `--parquet-dbnum` |
 | B | B.3 Verify binary 加 Parquet 路径 | complete | 2026-05-12 | commit `a8ce553f`，exit code 6 = parquet path fail；13 canonical raw 表 + summary JSON 全部落盘断言 |
 | B | B.4 B 阶段 PR | complete | 2026-05-12 | PR #14: https://github.com/happyrust/plant-model-gen/pull/14；`cargo check --features review` + `verify_model_writer_trait` 均 PASS |
-| C | C.1 BackendSelection 枚举 + DbOption | pending | — | — |
-| C | C.2 Orchestrator compare 路径 | pending | — | — |
-| C | C.3 C 阶段 PR | pending | — | — |
+| C | C.1 CompareModelWriterBackend wrapper | complete | 2026-05-12 | commit `2401268b`，trait 装饰器模式（zero-touch orchestrator），fail-fast；primary/candidate diff log policy；compare.rs +390 |
+| C | C.2 Factory + DbOption + CLI 接入 | complete | 2026-05-12 | commit `fb79afa8`，`model_writer_compare_with: Option<ModelWriterMode>`，validate 2c 守卫（拒 self-compare / drain-only / missing output_root），`--model-writer-compare-with` CLI |
+| C | C.3 Verify binary compare 路径 | complete | 2026-05-12 | commit `3300ed7d`，exit code 7 = compare wrapper fail；primary (mock) snapshot 校验 + candidate (parquet) 13 表落盘断言 |
+| C | C 阶段 PR | complete | 2026-05-12 | PR #15: https://github.com/happyrust/plant-model-gen/pull/15 （base = Phase B 分支，stack PR） |
 | D | D.1 DuckLakeModelWriterBackend 骨架 | pending | — | feature `ducklake` 守门 |
 | D | D.2 D 阶段 PR | pending | — | — |
 | E | E.1 validate-model-writer CLI umbrella | pending | — | — |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -261,9 +261,9 @@
 | C | C 阶段 PR | complete | 2026-05-12 | PR #15: https://github.com/happyrust/plant-model-gen/pull/15 （base = Phase B 分支，stack PR） |
 | D | D.1 DuckLakeModelWriterBackend 骨架 | complete | 2026-05-12 | commit `88071608`，feature `ducklake = []`，trait 8 方法全 `bail!`，工厂 cfg 守门；ModelWriterMode::DuckLake + parse + validate 守卫 |
 | D | D.2 D 阶段 PR | complete | 2026-05-12 | PR #16: https://github.com/happyrust/plant-model-gen/pull/16；`cargo check --features review` + `cargo check --features review,ducklake` 均 PASS |
-| E | E.1 validate-model-writer CLI umbrella | pending | — | — |
-| E | E.2 SQL parity scripts | pending | — | 13 张 Phase 1 表 × 2 个 SQL |
-| E | E.3 E 阶段 PR | pending | — | — |
+| E | E.1 diff-summary CLI | complete | 2026-05-12 | commit `023eb327`，`aios-database model-writer diff-summary --left ... --right ...` + `--fail-on-diff` 退出码 2；smoke：match→exit 0、diff→exit 2 |
+| E | E.2 SQL parity scripts | complete | 2026-05-12 | commit `10dcba4d`，13 张 Phase 1 表 × 2 SQL = 26 文件 + README + 维护脚本 _gen_sql.ps1（DuckDB read_json_auto，v4 换 read_parquet 一行改） |
+| E | E.3 E 阶段 PR | complete | 2026-05-12 | PR #17: https://github.com/happyrust/plant-model-gen/pull/17 |
 | F | F.1 take_missing_neg_carriers 拆 trait | pending | — | — |
 | F | F.2 BridgeContext 抽出 | pending | — | — |
 | F | F.3 F 阶段 PR | pending | — | small × 2 |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -99,3 +99,115 @@
 1. 用户确认 `findings.md §3` 待回答问题的最终选项（特别是 trait 命名、mock backend 启用方式）。
 2. 主仓 `feat/collab-api-consolidation` 工作区现有 `model_writer.rs` 未提交改动需要收口（提交或 stash），避免与 P4 rebase 冲突时混淆。
 3. 上述两点确认后，从 Task 1.1 开始按顺序实施。
+
+---
+
+## 2026-05-11 二期审核 + v2 收口
+
+> 触发：用户 2026-05-11 直接要求"审核当前 worktree 的 ModelWriteTrait 的实现"。
+> 审核结果：2 Critical / 5 Warning / 6 Note；plannotator v1 计划被退回 (DrainOnly 用途说明)，v2 已 approved。
+> 存档：`C:\Users\dpc\.plannotator\plans\2026-05-11-142958-modelwriterbackend-trait-v2-approved.md`
+
+### 自 b060860 以来的实际 HEAD 漂移（progress 同步）
+
+2026-05-09 P4 task 完成后，worktree 又进了 5 个 commit，进入文档目录 `docs/development/model-writer-storage/` 描述的 canonical raw boundary 阶段：
+
+| Commit | Title |
+|---|---|
+| `bf4bef80` | fix: resolve merge artifacts in workflow_sync, review_db, and remove stale patch blocks |
+| `f3c5750e` | Merge branch 'main' into feat/model-persistence-trait |
+| `a27d0685` | fix(deps): repair SurrealDB lock source |
+| `80fcc7eb` | Fix canonical raw record compilation |
+| `366cb275` | feat(model-writer): complete canonical raw coverage |
+| `04dbd9c3` | feat(model-writer): harden canonical validation CLI（当前 HEAD） |
+
+### 二期审核新发现（与 findings.md §4 联动）
+
+| 等级 | ID | 简述 | 修复 Task |
+|---|---|---|---|
+| Critical | C-A | `cli_modes::run_regen_model` 调 `cleanup` 但漏 `init`，违反 trait lifecycle 契约 | T1.1 |
+| Critical | C-B | DrainOnly 主管线快速路径绕过 trait 的 6 个中间方法，trait 化收益未真正兑现 — 用户拍板：保留快速路径作为 baseline | T1.2 |
+| Warning | W-A | `BooleanBridgeReport::skipped` 日志标签硬编码 `[model-writer:surreal]` 被多 backend 共用 | T2.1 |
+| Warning | W-B | `SurrealRecordKey::new` `starts_with` 分支会产出两种格式 record id | T2.2 |
+| Warning | W-C | `WriteBaseReport.missing_neg_carriers` 仍泄漏 `Vec<RefnoEnum>`；`#[non_exhaustive]` 实际无效 | T2.3 + P5 backlog |
+| Warning | W-D | `parquet.rs::CanonicalParquetWriter` 不实现 trait 却放在 `model_writer/` 顶层 | T2.4 |
+| Warning | W-E | `BooleanBridgeRequest::db_option` 仍暴露 `Arc<DbOption>` | T2.5（仅 TODO 标记）+ P5 backlog |
+| Note | N-1 | Cargo.toml `model-writer-drain` feature 死代码 | T3.1 |
+| Note | N-2 | mock backend 的 `injected_*` 字段未被 verify binary 使用 | T3.2 |
+| Note | N-3 | verify binary 只断言调用顺序前缀，强度不足 | T3.2 |
+| Note | N-4 | trait `name()` 改 const，dyn vtable 上不可行 → cancelled | T3.3 |
+| Note | N-5 | DrainOnly stats Mutex → atomic（性能优化） | P5 backlog |
+| Note | N-6 | `BooleanBridgeReport::skipped` 顺手 IO 违反构造器纯净 | 与 T2.1 合并 |
+
+### Decisions（不可逆架构约定）
+
+- **DrainOnly = baseline 模式**：跳过所有持久化、只跑生产端 + 调度，用于对比不同 backend 的写入耗时。`orchestrator.rs` 的快速路径 + `drain_only.rs` 中 6 个中间方法的"未路由" invariant 必须同时保留；只能整体改，不能拆。
+- **`WriteBaseReport.missing_neg_carriers` 短期保留**：拆 `take_missing_neg_carriers()` 推到 P5。
+- **`BooleanBridgeRequest::db_option` 短期保留**：抽 `BridgeContext` 推到 P5。
+- **`parquet.rs` 短期不接 trait 工厂**：与 docs/development/model-writer-storage Phase 1 共识一致，本轮只加位置说明。
+
+### P1 完成（2026-05-11）
+
+- **T1.1** cli_modes.rs:1738~1761 补 `init` 调用（包含 ModelWriterContext::from_db_option 注入）；添加 lifecycle 契约注释。`init_model_tables` 走 DEFINE TABLE 语义，幂等无副作用。
+- **T1.2** drain_only.rs 顶部加 module doc 锁定 DrainOnly baseline 架构 invariant；6 个中间方法函数体顶部各加 `architectural-invariant` 单行注释；orchestrator.rs:1112 快速路径上方加 9 行 `[arch]` 注释 + 重构前置条件。findings.md §3 表格新增 DrainOnly baseline 决策条目。
+
+### P2 完成（2026-05-11）
+
+- **T2.1** mod.rs:120-122 `BooleanBridgeReport::skipped` 把 `[model-writer:surreal]` 改为 `[model-writer:{pipeline}]`。
+- **T2.2** surreal.rs:284-308 `SurrealRecordKey::new` 删 `starts_with` 分支，白名单去 `:`；统一输出 `table:⟨raw_key⟩`。
+- **T2.3** mod.rs:155-167 删 `#[non_exhaustive]`，给 `missing_neg_carriers` 加 `///` doc 说明 P5 拆分计划。
+- **T2.4** parquet.rs:1 加 12 行 module doc；mod.rs:14, 28-31 加位置标注 (`Canonical raw record types & planner` / `Canonical raw sink scaffold`)。
+- **T2.5** mod.rs:88-89 给 `BooleanBridgeRequest::db_option` 加 `TODO(P5)` 注释。
+
+### P3 完成（2026-05-11）
+
+- **T3.1** Cargo.toml:256 删 `model-writer-drain = []`。`rg "model-writer-drain"` 仅在历史文档 `p2-implementation-guide.md:16` 一处残留（不动）。
+- **T3.2** verify binary 重写：
+  - 注入 `injected_reconcile_inserted=42` 和 `injected_missing_neg=vec![default, default]`，验证返回值精确匹配。
+  - 二次 `init` 安全断言（exit 5）。
+  - cleanup-without-init 安全断言（mock 路径，对应历史 cli_modes 残留场景）。
+  - snapshot 长度从 8 改为 9（含两次 init），并加"反例 — snapshot 不能含未预期方法名"硬检查。
+  - exit code 拓展：0 PASS / 1 trait err / 2 调用计数 / 3 顺序/反例 / 4 注入未被 honor / 5 二次 init 不安全。
+- **T3.3** findings.md N-4 标记 `Skipped 2026-05-11`，理由：dyn vtable 不能放 const。task_plan T5.2 标 `Cancelled 2026-05-11`。
+
+### P4 进行中（2026-05-11）
+
+- **T4.1** progress.md 同步至本节。
+- **T4.2** `git checkout -- src/options.rs` 清掉纯 CRLF/LF 噪声。其余 8 个文件都是真实改动，CRLF warning 由 git commit 时自动转换。
+- **T4.3 / T4.4** 等用户确认后再执行（按计划 v2 commit 分片 + push + gh pr create）。
+
+### Canonical raw boundary（平行工作流，不在本 PR 范围）
+
+- `src/fast_model/gen_model/canonical_records.rs`（新增 587L）
+- `src/fast_model/gen_model/model_writer/parquet.rs`（新增 254L，已加位置说明）
+- `docs/development/model-writer-storage/{00..08}-*.md`（9 文件 mission docs，untracked）
+
+未来 Phase 5 把 parquet.rs 升级为真正的 `ModelWriterBackend` 时与该 mission 合流。
+
+### Phase 进度表（二期）
+
+| Phase | Task | Status | 完成时间 | 备注 |
+|---|---|---|---|---|
+| P1 | T1.1 run_regen_model 补 init | complete | 2026-05-11 | cli_modes.rs:1743-1761；注释明确 lifecycle 契约 |
+| P1 | T1.2 DrainOnly baseline 文档/代码锁定 | complete | 2026-05-11 | drain_only.rs module doc + 6 个 invariant 注释；orchestrator.rs 9 行 [arch] 注释；findings.md §3 新增决策行 |
+| P2 | T2.1 skipped 日志去硬编码 | complete | 2026-05-11 | mod.rs:120-122 |
+| P2 | T2.2 SurrealRecordKey 去分支 | complete | 2026-05-11 | surreal.rs:284-308，白名单去 `:` |
+| P2 | T2.3 WriteBaseReport 去 non_exhaustive | complete | 2026-05-11 | mod.rs:155-167 |
+| P2 | T2.4 parquet.rs 位置说明 | complete | 2026-05-11 | parquet.rs:1 + mod.rs:14, 28-31 |
+| P2 | T2.5 BooleanBridgeRequest TODO | complete | 2026-05-11 | mod.rs:88-89 |
+| P3 | T3.1 删 model-writer-drain 死 feature | complete | 2026-05-11 | Cargo.toml |
+| P3 | T3.2 verify binary 增强 | complete | 2026-05-11 | 新增 INJECTED_RECONCILE、二次 init、cleanup-without-init、反例检查；exit code 拓展为 0-5 |
+| P3 | T3.3 N-4 / T5.2 Skipped | complete | 2026-05-11 | findings + task_plan 同步 |
+| P4 | T4.1 progress.md 同步 | complete | 2026-05-11 | 本节 |
+| P4 | T4.2 清 CRLF 噪声 | complete | 2026-05-11 | options.rs 还原；其余文件靠 git autocrlf 处理 |
+| P4 | T4.3 commit 分片 | pending | — | 待用户授权 |
+| P4 | T4.4 push + gh pr create | pending | — | 待用户授权 |
+
+### 验证记录（二期）
+
+| 时间 | 验证类型 | 命令 | 结果 |
+|---|---|---|---|
+| 2026-05-11 | IDE Lint | `ReadLints` × 8 个改动文件 | 无 lint 错误 |
+| 2026-05-11 | grep `model-writer-drain` in src/ | 死 feature 检查 | 0 命中（仅 p2-implementation-guide.md 历史文档残留） |
+| 2026-05-11 | grep `Option<Arc<dyn ModelWriterBackend>` | trait Option 化残留 | 0 命中 |
+| 2026-05-11 | Cargo build + Trait 契约 (verify binary) | `pwsh -NoProfile -File verify-mock.ps1` | 待跑（依赖本机 NASM 环境，P4 push 前补） |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -200,8 +200,8 @@
 | P3 | T3.3 N-4 / T5.2 Skipped | complete | 2026-05-11 | findings + task_plan 同步 |
 | P4 | T4.1 progress.md 同步 | complete | 2026-05-11 | 本节 |
 | P4 | T4.2 清 CRLF 噪声 | complete | 2026-05-11 | options.rs 还原；其余文件靠 git autocrlf 处理 |
-| P4 | T4.3 commit 分片 | pending | — | 待用户授权 |
-| P4 | T4.4 push + gh pr create | pending | — | 待用户授权 |
+| P4 | T4.3 commit 分片 | complete | 2026-05-11 | 5 commit: b4d93ca0 / c8faec3d / c63ea11e / 9678510c / 8bb69632 |
+| P4 | T4.4 push + gh pr create | complete | 2026-05-11 | https://github.com/happyrust/plant-model-gen/pull/11 |
 
 ### 验证记录（二期）
 
@@ -211,3 +211,58 @@
 | 2026-05-11 | grep `model-writer-drain` in src/ | 死 feature 检查 | 0 命中（仅 p2-implementation-guide.md 历史文档残留） |
 | 2026-05-11 | grep `Option<Arc<dyn ModelWriterBackend>` | trait Option 化残留 | 0 命中 |
 | 2026-05-11 | Cargo build + Trait 契约 (verify binary) | `pwsh -NoProfile -File verify-mock.ps1` | 待跑（依赖本机 NASM 环境，P4 push 前补） |
+
+---
+
+## 2026-05-12 v3 启动（plannotator approved）
+
+> 触发：用户 2026-05-12 直接要求 "继续使用 plannotator 规划 worktree model-persistence-trait 的实现进度"，AI 输出 v3 计划提交 plannotator，approved。
+> 存档：`C:\Users\dpc\.plannotator\plans\2026-05-11-014336-worktree-model-persistence-tra-approved.md`
+> 本地副本：`docs/plans/2026-05-09-model-write-trait-followup/v3-plan.md`
+
+### v3 目标
+
+在 v2 (PR #11) 落地的 trait abstraction 基础上，把 Parquet writer 升级为真正的 `ModelWriterBackend`，落地 orchestrator 多 backend 选择 + compare 模式，使 mission docs Phase 2 真正可用；同时清理 v2 残留的 worktree 脏文件与 9 份 untracked mission docs，按节奏拆分独立 PR。
+
+### v3 架构 invariants（沿用 v2 + 新增 4 条）
+
+新增 4 条：
+
+- Parquet writer 是 "file-oriented backend"，不替代 SurrealDB（mission 05）
+- DuckLake writer 在 v3 不实装，仅 feature-gated 骨架（trait impl 全 `bail!`），真正实装留 v4
+- compare 模式遵循 "fail fast, no silent fallback"
+- SurrealDB Cargo source 必须保持 `github.com/happyrust/surrealdb`
+
+### Phase 总览
+
+| Phase | 名称 | 独立 PR 分支 | 状态 |
+|---|---|---|---|
+| A | v2 残留 cleanup | （progress 同步 → PR #11；mission docs → `docs/model-writer-storage-mission`） | in_progress |
+| B | Parquet trait 化 | `feat/parquet-model-writer-backend` | pending |
+| C | Orchestrator backend selection + compare | `feat/model-writer-compare-mode` | pending |
+| D | DuckLake backend 骨架 | `feat/ducklake-backend-skeleton` | pending |
+| E | CLI + SQL validation 全套 | `feat/model-writer-validation-cli` | pending |
+| F | P5 backlog 收口 | 2 个 small PR | pending |
+
+### v3 milestones
+
+| Phase | Task | Status | 完成时间 | 备注 |
+|---|---|---|---|---|
+| A | A.1 审查 + 处置 3 文件 | in_progress | 2026-05-12 | mock.rs / options.rs CRLF 噪声已 checkout；progress.md + v3-plan.md 准备 commit |
+| A | A.2 mission docs docs-only PR | pending | — | 待 A.1 push 后启动 |
+| A | A.3 rebase origin/main | pending | — | 待 A.2 完成 |
+| B | B.1 ParquetModelWriterBackend 骨架 | pending | — | — |
+| B | B.2 接入 create_model_writer 工厂 | pending | — | — |
+| B | B.3 Verify binary 加 Parquet 路径 | pending | — | — |
+| B | B.4 B 阶段 PR | pending | — | — |
+| C | C.1 BackendSelection 枚举 + DbOption | pending | — | — |
+| C | C.2 Orchestrator compare 路径 | pending | — | — |
+| C | C.3 C 阶段 PR | pending | — | — |
+| D | D.1 DuckLakeModelWriterBackend 骨架 | pending | — | feature `ducklake` 守门 |
+| D | D.2 D 阶段 PR | pending | — | — |
+| E | E.1 validate-model-writer CLI umbrella | pending | — | — |
+| E | E.2 SQL parity scripts | pending | — | 13 张 Phase 1 表 × 2 个 SQL |
+| E | E.3 E 阶段 PR | pending | — | — |
+| F | F.1 take_missing_neg_carriers 拆 trait | pending | — | — |
+| F | F.2 BridgeContext 抽出 | pending | — | — |
+| F | F.3 F 阶段 PR | pending | — | small × 2 |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -248,13 +248,13 @@
 
 | Phase | Task | Status | 完成时间 | 备注 |
 |---|---|---|---|---|
-| A | A.1 审查 + 处置 3 文件 | complete (local) | 2026-05-12 | mock.rs / options.rs CRLF 噪声 checkout；commit `29fa19ab` 含 progress.md + v3-plan.md；push 待用户授权 |
-| A | A.2 mission docs docs-only PR | commit-ready | 2026-05-12 | 新 worktree `.worktrees/docs-mission`，新分支 `docs/model-writer-storage-mission`，commit `a6beb555` 9 文件 +477；push + `gh pr create` 待用户授权 |
+| A | A.1 审查 + 处置 3 文件 | complete | 2026-05-12 | mock.rs / options.rs CRLF 噪声 checkout；commit `29fa19ab` + `58844c88` pushed to `feat/model-persistence-trait`，PR #11 自动 pick up |
+| A | A.2 mission docs docs-only PR | complete | 2026-05-12 | 分支 `docs/model-writer-storage-mission` commit `a6beb555` pushed；PR #13: https://github.com/happyrust/plant-model-gen/pull/13 |
 | A | A.3 rebase origin/main | deferred | — | PR #11 review 中，force-push 会让评论失效；推迟到 PR #11 合并阶段处理（GH UI merge --rebase 或合并前再 rebase） |
-| B | B.1 ParquetModelWriterBackend 骨架 | pending | — | — |
-| B | B.2 接入 create_model_writer 工厂 | pending | — | — |
-| B | B.3 Verify binary 加 Parquet 路径 | pending | — | — |
-| B | B.4 B 阶段 PR | pending | — | — |
+| B | B.1 ParquetModelWriterBackend 骨架 | complete | 2026-05-12 | commit `e93c559b`，parquet.rs +515/-262，含 8 个 trait 方法 + module doc 重写 |
+| B | B.2 接入 create_model_writer 工厂 | complete | 2026-05-12 | commit `0d91b496`，ModelWriterMode::Parquet + DbOptionExt 字段 + validate 守卫 + CLI flags `--parquet-output-root` / `--parquet-dbnum` |
+| B | B.3 Verify binary 加 Parquet 路径 | complete | 2026-05-12 | commit `a8ce553f`，exit code 6 = parquet path fail；13 canonical raw 表 + summary JSON 全部落盘断言 |
+| B | B.4 B 阶段 PR | complete | 2026-05-12 | PR #14: https://github.com/happyrust/plant-model-gen/pull/14；`cargo check --features review` + `verify_model_writer_trait` 均 PASS |
 | C | C.1 BackendSelection 枚举 + DbOption | pending | — | — |
 | C | C.2 Orchestrator compare 路径 | pending | — | — |
 | C | C.3 C 阶段 PR | pending | — | — |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -264,6 +264,6 @@
 | E | E.1 diff-summary CLI | complete | 2026-05-12 | commit `023eb327`，`aios-database model-writer diff-summary --left ... --right ...` + `--fail-on-diff` 退出码 2；smoke：match→exit 0、diff→exit 2 |
 | E | E.2 SQL parity scripts | complete | 2026-05-12 | commit `10dcba4d`，13 张 Phase 1 表 × 2 SQL = 26 文件 + README + 维护脚本 _gen_sql.ps1（DuckDB read_json_auto，v4 换 read_parquet 一行改） |
 | E | E.3 E 阶段 PR | complete | 2026-05-12 | PR #17: https://github.com/happyrust/plant-model-gen/pull/17 |
-| F | F.1 take_missing_neg_carriers 拆 trait | pending | — | — |
-| F | F.2 BridgeContext 抽出 | pending | — | — |
-| F | F.3 F 阶段 PR | pending | — | small × 2 |
+| F | F.1 take_missing_neg_carriers 拆 trait | complete | 2026-05-12 | commit `f276256c` + `c8c0f5fe`，trait 加 default-empty method；删 WriteBaseReport.missing_neg_carriers + orchestrator Arc<Mutex<HashSet>>；verify binary 加 drain 幂等断言；PR #18 |
+| F | F.2 BridgeContext 抽出 | in_progress | — | — |
+| F | F.3 F 阶段 PR | pending | — | F.1 已独立 PR #18；F.2 待立 |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -248,9 +248,9 @@
 
 | Phase | Task | Status | 完成时间 | 备注 |
 |---|---|---|---|---|
-| A | A.1 审查 + 处置 3 文件 | in_progress | 2026-05-12 | mock.rs / options.rs CRLF 噪声已 checkout；progress.md + v3-plan.md 准备 commit |
-| A | A.2 mission docs docs-only PR | pending | — | 待 A.1 push 后启动 |
-| A | A.3 rebase origin/main | pending | — | 待 A.2 完成 |
+| A | A.1 审查 + 处置 3 文件 | complete (local) | 2026-05-12 | mock.rs / options.rs CRLF 噪声 checkout；commit `29fa19ab` 含 progress.md + v3-plan.md；push 待用户授权 |
+| A | A.2 mission docs docs-only PR | commit-ready | 2026-05-12 | 新 worktree `.worktrees/docs-mission`，新分支 `docs/model-writer-storage-mission`，commit `a6beb555` 9 文件 +477；push + `gh pr create` 待用户授权 |
+| A | A.3 rebase origin/main | deferred | — | PR #11 review 中，force-push 会让评论失效；推迟到 PR #11 合并阶段处理（GH UI merge --rebase 或合并前再 rebase） |
 | B | B.1 ParquetModelWriterBackend 骨架 | pending | — | — |
 | B | B.2 接入 create_model_writer 工厂 | pending | — | — |
 | B | B.3 Verify binary 加 Parquet 路径 | pending | — | — |

--- a/docs/plans/2026-05-09-model-write-trait-followup/progress.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/progress.md
@@ -235,14 +235,14 @@
 
 ### Phase 总览
 
-| Phase | 名称 | 独立 PR 分支 | 状态 |
-|---|---|---|---|
-| A | v2 残留 cleanup | （progress 同步 → PR #11；mission docs → `docs/model-writer-storage-mission`） | in_progress |
-| B | Parquet trait 化 | `feat/parquet-model-writer-backend` | pending |
-| C | Orchestrator backend selection + compare | `feat/model-writer-compare-mode` | pending |
-| D | DuckLake backend 骨架 | `feat/ducklake-backend-skeleton` | pending |
-| E | CLI + SQL validation 全套 | `feat/model-writer-validation-cli` | pending |
-| F | P5 backlog 收口 | 2 个 small PR | pending |
+| Phase | 名称 | 独立 PR 分支 | 状态 | PR |
+|---|---|---|---|---|
+| A | v2 残留 cleanup | progress 同步 + mission docs PR | complete | #11 (incr) + #13 |
+| B | Parquet trait 化 | `feat/parquet-model-writer-backend` | complete | #14 |
+| C | Orchestrator backend selection + compare | `feat/model-writer-compare-mode` | complete | #15 |
+| D | DuckLake backend 骨架 | `feat/ducklake-backend-skeleton` | complete | #16 |
+| E | CLI + SQL validation 全套 | `feat/model-writer-validation-cli` | complete | #17 |
+| F | P5 backlog 收口 | 2 个 small PR | complete | #18 + #19 |
 
 ### v3 milestones
 
@@ -265,5 +265,5 @@
 | E | E.2 SQL parity scripts | complete | 2026-05-12 | commit `10dcba4d`，13 张 Phase 1 表 × 2 SQL = 26 文件 + README + 维护脚本 _gen_sql.ps1（DuckDB read_json_auto，v4 换 read_parquet 一行改） |
 | E | E.3 E 阶段 PR | complete | 2026-05-12 | PR #17: https://github.com/happyrust/plant-model-gen/pull/17 |
 | F | F.1 take_missing_neg_carriers 拆 trait | complete | 2026-05-12 | commit `f276256c` + `c8c0f5fe`，trait 加 default-empty method；删 WriteBaseReport.missing_neg_carriers + orchestrator Arc<Mutex<HashSet>>；verify binary 加 drain 幂等断言；PR #18 |
-| F | F.2 BridgeContext 抽出 | in_progress | — | — |
-| F | F.3 F 阶段 PR | pending | — | F.1 已独立 PR #18；F.2 待立 |
+| F | F.2 BridgeContext 抽出 | complete | 2026-05-12 | commit `738c31b2`：把 `Arc<DbOption>` 从 `BooleanBridgeRequest` 拿掉，改由 `ModelWriterContext::db_option` 在 init 时缓存；surreal `run_boolean_bridge` 从 cached ctx 取 db_option；orchestrator 两处构造点简化；trait 接口面再减一字段 |
+| F | F.3 F 阶段 PR | complete | 2026-05-12 | F.1 PR #18 + F.2 PR #19: https://github.com/happyrust/plant-model-gen/pull/19 |

--- a/docs/plans/2026-05-09-model-write-trait-followup/task_plan.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/task_plan.md
@@ -399,9 +399,9 @@ git -C .worktrees/model-persistence-trait log --oneline feat/collab-api-consolid
 
 **Steps**：调研 nightly 支持度，对比 dyn trait + 性能开销，评估是否值得在 hot path 上做。**输出**：评估报告归档到 `docs/plans/2026-05-09-model-write-trait-followup/n3-async-fn-evaluation.md`。
 
-#### Task 5.2 — `name()` 改 `const NAME`（N4）
+#### Task 5.2 — ~~`name()` 改 `const NAME`（N4）~~ **Cancelled 2026-05-11**
 
-**Steps**：trait 改为关联常量，所有实现改用 `const NAME: &'static str = "..."`。
+trait 通过 `Arc<dyn ModelWriterBackend>` 走 vtable 调用，关联 const 不进 vtable，无法替代 method。保留 method 形式即可，无需独立 Phase 5 立项。
 
 #### Task 5.3 — 清理 `write_base_batch` 空 mesh_results 包袱（N6）
 

--- a/docs/plans/2026-05-09-model-write-trait-followup/v3-plan.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/v3-plan.md
@@ -1,0 +1,453 @@
+# Worktree `model-persistence-trait` 推进计划 (v3)
+
+> **历史脉络**：
+> - v1 (2026-05-11-142521) 被拒：DrainOnly 快路径用途说明缺失
+> - v2 (2026-05-11-142958) approved：trait abstraction follow-up，已落地 PR #11 (5 commits 至 HEAD `8bb69632`)
+> - **本 v3**：在 PR #11 基础上继续推进 multi-backend 实装与 canonical raw boundary 平行工作流的合流
+> - plannotator 存档：`C:\Users\dpc\.plannotator\plans\2026-05-11-014336-worktree-model-persistence-tra-approved.md`
+
+> **For Agent**：本文件是结构化数据。所有 Task 按 `## 5. 详细任务` 顺序执行，每完成一个立即更新 `docs/plans/2026-05-09-model-write-trait-followup/progress.md` 的 v3 小节。
+
+**仓库**：https://github.com/happyrust/plant-model-gen.git · worktree `.worktrees/model-persistence-trait` · 分支 `feat/model-persistence-trait` · HEAD `8bb69632`
+
+**Goal**：在 v2 (PR #11) 落地的 trait abstraction 基础上，把 `model_writer/parquet.rs` 从 "canonical raw sink scaffold" 升级为真正的 `ModelWriterBackend`，并落地 orchestrator 多 backend 选择 + compare 模式，使 mission docs Phase 2 真正可用；同时清理 v2 残留的 3 个未提交脏文件与 9 份 untracked mission docs，按节奏拆分独立 PR。
+
+---
+
+## 0. 架构既定决策 (Architecture Invariants — 沿用 v2 + 新增)
+
+沿用 v2 的 4 条：
+
+1. DrainOnly 快路径 = baseline 模式（跳过持久化作 IO 耗时对比基准），不允许重构进主管线。
+2. DrainOnly backend 只走 `init` / `finalize` 两个 lifecycle 方法，其余 6 个为 mock/verify 防御性存在。
+3. DrainOnly stats 走旧 `run_drain_only_sink` 函数，不联动 trait 中间方法。
+4. canonical_records.rs / parquet.rs / docs/development/model-writer-storage/ 是平行工作。
+
+**v3 新增**：
+
+5. **Parquet writer 是 "file-oriented backend"**，不替代 SurrealDB，定位见 mission 05-parquet-writer.md。本轮把它升级为 trait 实现的目标只是 "可被 `create_model_writer` 工厂构造、可走主管线"，不追求与 Surreal 的 SQL/projection 完整 parity。
+6. **DuckLake writer 在本 v3 不实装**，仅做最小骨架（trait impl 全 `bail!("not yet implemented")`），避免引入 `duckdb` crate 依赖污染本轮 review。真正实装留 v4。
+7. **compare 模式遵循 mission 03 "fail fast, no silent fallback"**：任一 backend 写失败立即终止，不静默忽略。
+8. **SurrealDB Cargo source 不变**：必须保持 `github.com/happyrust/surrealdb`（mission 00 / 07 多次强调）。
+
+---
+
+## 1. 当前基线
+
+| 维度 | 状态 |
+|---|---|
+| Worktree HEAD | `8bb69632` (v2 5 commits 已 push 至 PR #11) |
+| 工作区未提交 | 3 文件 modified: `progress.md` / `mock.rs` / `options.rs`；9 份 untracked mission docs in `docs/development/model-writer-storage/` |
+| Trait | `ModelWriterBackend` (8 方法，v2 已纯化) |
+| Backend 实现 | Surreal（主） / DrainOnly（baseline） / RecordingBackend（mock，feature-gated） |
+| Parquet scaffold | `CanonicalParquetWriter` 不实现 trait，目前用 JSONL fallback + `validate-canonical-parquet` CLI 子命令 |
+| Canonical records | `canonical_records.rs` (587L) — 13 张 Phase 1 表的 raw record 结构 + `CanonicalRawPlanner` |
+| DuckLake | 仅 mission docs (`04-ducklake-writer.md`)，无代码 |
+| PR #11 状态 | open，等 review |
+
+---
+
+## 2. 范围与不做事项
+
+**做**：
+
+1. **A 阶段**：v2 残留 cleanup —— commit 3 文件、决定 9 份 mission docs 的归属 PR、保证 worktree 干净。
+2. **B 阶段**：`CanonicalParquetWriter` 升级为 `ModelWriterBackend` 实现 + 接入 `create_model_writer` 工厂。
+3. **C 阶段**：orchestrator 加 `BackendSelection` 枚举（surreal/parquet/ducklake/compare），DbOption 增 `model_writer_compare_with` 字段。
+4. **D 阶段**：`DuckLakeModelWriterBackend` 最小骨架（trait impl 全 `bail!`），仅占位以便 v4 推进。
+5. **E 阶段**：CLI + SQL validation 全套——把现有 `validate-canonical-parquet` 扩为 `validate-model-writer` 子命令族，覆盖 Phase 1 13 张表的 row count parity 检查。
+6. **F 阶段**：P5 backlog 收口（`take_missing_neg_carriers` / `BridgeContext` 拆分），保留 `async fn in trait` 评估留 v4。
+7. 每个阶段独立 PR，避免 PR #11 review 阻塞下游工作。
+
+**不做**：
+
+- 不跑 `cargo test`（AGENTS.md 禁，沿用 verify binary + ps1 脚本）。
+- 不重写 Surreal backend 的 SQL helper（已纯化，无新发现问题）。
+- 不实装 DuckLake 真实写入（D 阶段仅骨架，留 v4）。
+- 不动 DrainOnly 快路径与中间方法语义（v2 锁定）。
+- 不引入 `duckdb` crate 依赖（避免污染 PR），仅在 D 阶段加 `#[cfg(feature = "ducklake")]` 守门的骨架代码。
+- 不动其他 worktree（pe-transform-backends / perf-* / room-compute-3x）。
+- 不跨仓修改（rs-core / pdms-io-fork / plant3d-web 不动）。
+- 不破坏现有日志契约（`[model-writer:*]` 前缀 + `[batch_perf] batch=...`）。
+
+---
+
+## 3. 阶段总览
+
+| Phase | 名称 | 解决的问题 / 推进的能力 | 预估改动量 | 独立 PR? |
+|---|---|---|---|---|
+| A | v2 残留 cleanup | worktree 脏文件 + untracked docs | ~50 行 | 是（docs-only + small fix） |
+| B | Parquet trait 化 | mission Phase 2 部分兑现，多 backend 实证 | ~250 行新代码 + ~30 行 orchestrator 接入 | 是 |
+| C | Orchestrator backend selection + compare | mission Phase 3 主体兑现 | ~150 行 | 是（依赖 B） |
+| D | DuckLake backend 骨架 | 为 v4 准备 + 接口验证 | ~80 行 + feature flag | 是（small） |
+| E | CLI + SQL validation 全套 | mission Phase 4 兑现 | ~200 行 CLI + ~150 行 SQL | 是 |
+| F | P5 backlog 收口 | 把 P5 中可在本轮完成的拆出来 | ~100 行 | 1-2 个 small PR |
+
+---
+
+## 4. 风险
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| PR #11 review 期间合 main 引入冲突 | 中 | A 阶段先 `git fetch && git rebase origin/main`，A 之后任何 Phase 启动前都 sync 一次 |
+| Parquet 写入引入 `arrow`/`parquet` crate 依赖膨胀 | 中 | B 阶段先沿用现有 JSONL fallback（mission 05 已认可）；真正 `.parquet` 物化推迟到独立 PR |
+| compare 模式双写性能下降 | 中 | C 阶段加 `compare_mode_max_batch_size` 节流，文档警告 "compare 模式仅用于 validation，不上生产" |
+| DuckLake 骨架 `bail!` 出现在 release 路径 | 高 | D 阶段强制 `#[cfg(feature = "ducklake")]` 守门，`Cargo.toml` 默认不启用；`create_model_writer` 在未启 feature 时 `bail!("ducklake backend requires --features ducklake")` |
+| validate-model-writer CLI 与现有 `validate-canonical-parquet` 命名冲突 | 低 | E 阶段先 alias 兼容老命令，新增 `validate-model-writer` 作为 umbrella 命令 |
+| 9 份 mission docs commit 到 trait PR 会让 review 范围模糊 | 中 | A 阶段把 mission docs 单独发 docs PR（不阻塞代码 PR） |
+| Phase F 拆 `take_missing_neg_carriers` 改 trait 签名会破 mock + verify binary | 中 | F 阶段同时改 mock.rs + verify binary，跑 `verify-mock.ps1` 兜底 |
+
+---
+
+## 5. 详细任务
+
+### Phase A：v2 残留 cleanup（独立 PR：mission-docs + small fix）
+
+#### Task A.1 — 审查 3 个未提交文件
+
+**Files**：
+- `docs/plans/2026-05-09-model-write-trait-followup/progress.md`
+- `src/fast_model/gen_model/model_writer/mock.rs`
+- `src/options.rs`
+
+**判定**（2026-05-12 执行已确认）：
+- `mock.rs` / `options.rs`：纯 CRLF/LF 噪声（diff 为空），`git checkout --` 还原
+- `progress.md`：真实改动（T4.3/T4.4 状态从 pending 改为 complete + PR #11 URL）+ v3 milestones 表追加
+
+**Steps**：
+1. `git checkout -- src/fast_model/gen_model/model_writer/mock.rs src/options.rs` （已执行）
+2. 在 progress.md 末尾追加 "## 2026-05-12 v3 启动" 章节 + v3 milestones 表
+3. 新增 `docs/plans/2026-05-09-model-write-trait-followup/v3-plan.md`（本文件）
+4. commit：`docs(plan): publish v3 plan + sync v2 progress status to PR #11`
+5. push 到 `feat/model-persistence-trait`（PR #11 自动 pick up，**不 amend、不 force**）
+
+**Verify**：`git status --short` 仅留 mission docs 的 `??` 行。
+
+---
+
+#### Task A.2 — Mission docs 独立 docs-only PR
+
+**Files**：`docs/development/model-writer-storage/{00..08}-*.md` (9 文件)
+
+**Steps**：
+1. 基于 `origin/main` 起新分支 `docs/model-writer-storage-mission`
+2. `git add docs/development/model-writer-storage/` 并 commit：`docs(model-writer-storage): add Phase 1 mission docs (overview + canonical schema + backend roadmap)`
+3. push + `gh pr create`，PR body 引用 mission 00 overview
+4. PR 标题：`docs(model-writer-storage): Phase 1 mission docs (canonical raw + parquet/ducklake roadmap)`
+5. PR URL 写回 worktree progress.md "v3 milestones" 表
+
+**Expected**：mission docs 走独立 review，不与 trait abstraction PR #11 缠绕，不阻塞下游 B/C/D 阶段。
+
+**Verify**：`gh pr list --search "head:docs/model-writer-storage-mission"` 返回一行。
+
+---
+
+#### Task A.3 — 同步 main 到 worktree
+
+**Steps**：
+```powershell
+git -C .worktrees/model-persistence-trait fetch origin
+git -C .worktrees/model-persistence-trait rebase origin/main
+```
+冲突处理原则：保留 trait 化骨架，main 上的小改按语义合入。
+
+**Expected**：worktree HEAD 基于最新 `origin/main`，PR #11 force-push 一次（用户授权前提下）。
+
+**Verify**：`git log --oneline origin/main..HEAD` 仍是 v2 那 5 commit + A.1 增量。
+
+---
+
+### Phase B：Parquet trait 化（独立 PR）
+
+> 依赖：A 完成。
+
+#### Task B.1 — `ParquetModelWriterBackend` 骨架
+
+**Files**：
+- Modify: `src/fast_model/gen_model/model_writer/parquet.rs`
+- Modify: `src/fast_model/gen_model/model_writer/mod.rs`
+
+**Steps**：
+1. 在 parquet.rs 新增 `pub struct ParquetModelWriterBackend { writer: Arc<Mutex<CanonicalParquetWriter>>, context: OnceLock<ModelWriterContext> }`
+2. impl `ModelWriterBackend`：
+   - `name()` → `"parquet"`
+   - `init` → 缓存 context；调 `CanonicalParquetWriter::ensure_output_layout` 准备目录
+   - `cleanup` → 清理目标 `dbnum/refno` 范围下旧文件（按 mission 05 layout：`output/<project>/model_writer_storage/raw/<table>/project_name=...`）
+   - `write_base_batch` → 收 batch，调 `CanonicalRawPlanner::plan_from_base` 转 canonical records，调 writer JSONL fallback 落盘；返回 `WriteBaseReport { batch_id, missing_neg_count: 0 }`
+   - `persist_mesh_results` → batch.file_mesh_state=true 时跳过；否则按 mesh canonical records 落盘
+   - `write_inst_relate_aabb` → canonical inst_relate_aabb 落盘
+   - `reconcile_missing_neg` → 读取已落盘 inst_relate / neg_relate，做内存 set diff，返回 inserted 行数（≤ Surreal 语义近似，标 "approximate" 日志）
+   - `run_boolean_bridge` → 返回 `BooleanBridgeReport::skipped("parquet", 0, "phase2_boolean_not_supported")`（mission 05 明确 boolean 是 Phase 2）
+   - `finalize` → 把 `CanonicalParquetWriter` flush + summary JSON 输出（mission 07 §2a 已有约定）
+3. mod.rs 顶部 `pub use parquet::ParquetModelWriterBackend;`，把 "Canonical raw sink (not a backend)" 注释升级为 "Canonical Parquet/JSONL sink backend"
+
+**Verify**：`cargo check --bin plant_db_cli --features review` 通过；`ReadLints` 通过。
+
+---
+
+#### Task B.2 — 接入 `create_model_writer` 工厂
+
+**Files**：`src/fast_model/gen_model/model_writer/mod.rs`
+
+**Steps**：
+1. `ModelWriterMode` 加 `Parquet { output_root: PathBuf }` 变体（或单独的 `parquet_output_root` 字段挂在 DbOption 上，看哪种侵入小）
+2. `create_model_writer` match 加分支：`ModelWriterMode::Parquet { output_root } => Arc::new(ParquetModelWriterBackend::new(output_root.clone())?)`
+3. `options.validate_model_writer_features` 加守卫：Parquet 模式不需要 `use_surrealdb`，但要求 `output_root` 可写
+
+**Verify**：`cargo check` 通过；用 `model_writer_mode=parquet` 跑一个 dbnum 应成功落盘到 mission 05 §Layout 描述的目录结构。
+
+---
+
+#### Task B.3 — Verify binary 加 Parquet 路径
+
+**Files**：`src/bin/verify_model_writer_trait.rs`
+
+**Steps**：
+1. 在现有 RecordingBackend 验证之后，加一段 `ParquetModelWriterBackend` 走完整 trait 8 方法的 e2e
+2. 校验目标目录有 13 张 canonical raw 表的 JSONL/summary 文件
+3. exit code 拓展：6 = parquet path fail
+
+**Verify**：`pwsh -NoProfile -File docs/plans/2026-05-09-model-write-trait-followup/verify-mock.ps1` exit=0。
+
+---
+
+#### Task B.4 — B 阶段 PR
+
+**Steps**：
+1. 分支 `feat/parquet-model-writer-backend`
+2. commit 分片：B.1 (骨架) / B.2 (factory + DbOption) / B.3 (verify)
+3. PR 标题：`feat(model-writer): wire Parquet backend into ModelWriterBackend trait`
+4. PR body 引用 mission 05-parquet-writer.md + B.1 接入说明
+
+---
+
+### Phase C：Orchestrator backend selection + compare 模式
+
+> 依赖：B 完成。
+
+#### Task C.1 — `BackendSelection` 枚举
+
+**Files**：
+- Modify: `src/options.rs`（DbOption）
+- Modify: `src/fast_model/gen_model/model_writer/mod.rs`
+
+**Steps**：
+1. DbOption 加字段：`pub model_writer_compare_with: Option<ModelWriterMode>`（default None）
+2. `create_model_writer` 改返回 `(Arc<dyn ModelWriterBackend>, Option<Arc<dyn ModelWriterBackend>>)`，第二个是 compare backend
+3. 或者更稳：保持 `create_model_writer` 单返回，新增 `create_compare_writer` 工厂；orchestrator 决策是否拉起 compare
+
+**Verify**：`cargo check` 通过；`ReadLints` 通过。
+
+---
+
+#### Task C.2 — Orchestrator compare 路径
+
+**Files**：`src/fast_model/gen_model/orchestrator.rs`
+
+**Steps**：
+1. `process_index_tree_generation` 入参拓展为 `(primary: Arc<dyn ModelWriterBackend>, compare: Option<Arc<dyn ModelWriterBackend>>)`
+2. 每个 trait 方法调用点：先调 primary，再调 compare（compare fail 立即 bail，不静默）
+3. `finalize` 时输出 primary + compare 两份 summary，diff 关键字段（batch counts / raw rows by table）
+4. 日志加 `[model-writer:compare] primary={surreal} candidate={parquet} table={inst_relate} primary_rows=N candidate_rows=M`
+
+**Verify**：用最小 dbnum 同时跑 `model_writer_mode=surreal, compare_with=parquet`，确认两个 backend 都落数据；compare 模式日志输出 diff。
+
+---
+
+#### Task C.3 — C 阶段 PR
+
+**Steps**：
+1. 分支 `feat/model-writer-compare-mode`
+2. commit 分片：C.1 (enum + DbOption) / C.2 (orchestrator)
+3. PR 标题：`feat(model-writer): add compare mode for dual-write parity validation`
+
+---
+
+### Phase D：DuckLake backend 骨架
+
+> 依赖：C 完成（确认 `BackendSelection` 枚举位置）。
+
+#### Task D.1 — `DuckLakeModelWriterBackend` 占位
+
+**Files**：
+- Create: `src/fast_model/gen_model/model_writer/ducklake.rs`
+- Modify: `src/fast_model/gen_model/model_writer/mod.rs`
+- Modify: `Cargo.toml`
+
+**Steps**：
+1. Cargo.toml 加 `ducklake = []` feature（暂不引 `duckdb` crate）
+2. ducklake.rs `#![cfg(feature = "ducklake")]`，定义 `pub struct DuckLakeModelWriterBackend { ... }`
+3. impl 所有 8 个 trait 方法 → 全 `bail!("DuckLake backend skeleton, not yet implemented (mission docs/04). Use parquet/surreal in v3.")`
+4. mod.rs 在 `#[cfg(feature = "ducklake")]` 守门下 `pub use ducklake::DuckLakeModelWriterBackend;`
+5. `create_model_writer` match 加 DuckLake 分支：未启 feature 时 `bail!("ducklake requires --features ducklake build")`，启了 feature 时返回骨架
+
+**Verify**：默认 `cargo check` 不带 feature 跑通；`cargo check --features ducklake` 也跑通。
+
+---
+
+#### Task D.2 — D 阶段 PR（small）
+
+**Steps**：
+1. 分支 `feat/ducklake-backend-skeleton`
+2. commit：单 commit `feat(model-writer): add DuckLake backend skeleton behind ducklake feature`
+3. PR body 强调 "v3 仅骨架，真实写入留 v4，主要为 v4 PR 不动 trait 签名做准备"
+
+---
+
+### Phase E：CLI + SQL validation 全套（独立 PR）
+
+> 依赖：B 完成（Parquet 已可作为 candidate backend 输出 13 张表的数据）。
+
+#### Task E.1 — `validate-model-writer` CLI umbrella
+
+**Files**：`src/cli_modes.rs`（或 model-writer 子模块）
+
+**Steps**：
+1. 新增 CLI 子命令族 `aios-database model-writer <subcmd>`：
+   - `validate-canonical-parquet`（保留现有，alias）
+   - `validate-compare --primary surreal --candidate parquet --dbnum N`：跑 compare 模式生成两份数据并执行 E.2 SQL 检查
+   - `diff-summary --left ... --right ...`：仅做 summary JSON 比较
+2. 命令出参 JSON 化（mission 07 §2a 已建立模式）
+
+**Verify**：`aios-database model-writer validate-compare --primary surreal --candidate parquet --dbnum <small>` 退出码 0 + JSON 报告。
+
+---
+
+#### Task E.2 — SQL parity scripts
+
+**Files**：
+- Create: `scripts/sql/model-writer-parity/*.sql`
+- Create: `scripts/sql/model-writer-parity/README.md`
+
+**Steps**：
+1. 13 张 Phase 1 表，每张表至少 2 个 SQL：row count + key-set diff（mission 07 §3 列表照抄）
+2. 用 DuckDB 读 Parquet/JSONL，配合 SurrealDB export 走 SQL
+3. README 给运行示例
+
+**Verify**：手动跑过一遍 SQL，输出文档化到 README。
+
+---
+
+#### Task E.3 — E 阶段 PR
+
+**Steps**：
+1. 分支 `feat/model-writer-validation-cli`
+2. PR 标题：`feat(model-writer): add validate-compare CLI + Phase 1 SQL parity scripts`
+
+---
+
+### Phase F：P5 backlog 收口（1-2 个 small PR）
+
+#### Task F.1 — `take_missing_neg_carriers` 拆 trait 方法（P5 backlog #1）
+
+**Files**：
+- Modify: `src/fast_model/gen_model/model_writer/mod.rs`
+- Modify: `src/fast_model/gen_model/model_writer/surreal.rs`
+- Modify: `src/fast_model/gen_model/model_writer/mock.rs`
+- Modify: `src/fast_model/gen_model/model_writer/parquet.rs`（B 阶段产出）
+- Modify: `src/fast_model/gen_model/orchestrator.rs`
+- Modify: `src/bin/verify_model_writer_trait.rs`
+
+**Steps**：
+1. 在 trait 加 `async fn take_missing_neg_carriers(&self) -> Vec<RefnoEnum> { Vec::new() }`（有 default）
+2. `WriteBaseReport` 删 `missing_neg_carriers` 字段
+3. SurrealBackend 内部 `Mutex<Vec<RefnoEnum>>`，`write_base_batch` 累计，`take_missing_neg_carriers` drain
+4. mock backend 同 pattern + `injected_missing_neg` 走 take
+5. orchestrator 改读取方式
+
+**Verify**：`verify-mock.ps1` 退出 0；`cargo check` 通过。
+
+---
+
+#### Task F.2 — `BridgeContext` 抽出（P5 backlog #2）
+
+**Files**：同 F.1（去掉 verify binary）
+
+**Steps**：
+1. 新增 `pub struct BridgeContext { pub mode: BridgeMode, pub use_surrealdb: bool, pub defer_db_write: bool, pub bool_tasks_count: usize }`
+2. `BooleanBridgeRequest::db_option` 字段删除，换成 `pub context: BridgeContext`
+3. orchestrator 构造时填 context
+4. SurrealBackend 改读 context（不再走 `Arc<DbOption>`）
+5. mock + parquet backend 同步
+
+**Verify**：同 F.1。
+
+---
+
+#### Task F.3 — F 阶段 PR (small × 2)
+
+**Steps**：
+1. F.1 单独 PR：`refactor(model-writer): hoist missing_neg_carriers to trait method`
+2. F.2 单独 PR：`refactor(model-writer): replace BooleanBridgeRequest::db_option with BridgeContext`
+3. F 不收 `async fn in trait` 评估（留 v4 调研）
+
+---
+
+## 6. 验证策略
+
+| 验证类型 | 手段 | 触发时机 |
+|---|---|---|
+| IDE Lint | `ReadLints` | 每个 Task 后 |
+| 编译 | `cargo check --bin plant_db_cli --features review` | 每个 Phase 末 |
+| 编译（ducklake 守门） | `cargo check --features ducklake` | D 阶段末 |
+| Trait 契约 | `pwsh -NoProfile -File docs/plans/2026-05-09-model-write-trait-followup/verify-mock.ps1` | B.3 / F.1 / F.2 后 |
+| Parquet 落盘 | 跑一个最小 dbnum `model_writer_mode=parquet`，校验 13 张表的 JSONL/summary 完整 | B 阶段末 |
+| Compare 模式 | 同 dbnum `compare_with=parquet`，输出 diff JSON | C 阶段末 |
+| SQL parity | E.2 SQL 脚本手动跑过一次 | E 阶段末 |
+| 集成 | 起 `web_server` 跑 `/api/health` + admin smoke | 每个 Phase PR push 前 |
+
+---
+
+## 7. 错误处理协议 (3-Strike)
+
+```
+ATTEMPT 1: 诊断 + 修复，错误写 progress.md "v3 errors" 表
+ATTEMPT 2: 换不同实现路径
+ATTEMPT 3: 质疑前置假设（如：Parquet 真能 JSONL fallback 走 trait 吗？）
+AFTER 3 FAILURES: progress.md 记录三次尝试详情，调 best-mcp-sqlite-16 check_messages 升级用户
+```
+
+---
+
+## 8. 约束与边界
+
+- 不动其他 worktree / 不跨仓修改 / 不动主分支未提交内容
+- 未经用户明确授权不 `push -f` / 不 amend 已推送 commit
+- 不破坏 `[model-writer:*]` 日志契约
+- 不动 DrainOnly 快路径（v2 锁定）
+- 不引入 `duckdb` / `arrow` / `parquet` crate（D 阶段仅 feature-gated 骨架；真正物化留 v4）
+- SurrealDB Cargo source 必须保持 `github.com/happyrust/surrealdb`（mission 00/07）
+
+---
+
+## 9. 完成判定
+
+- [ ] **A**：worktree `git status` 干净（仅留计划性 untracked）；mission docs PR 已开
+- [ ] **B**：`model_writer_mode=parquet` 单 backend 跑通最小 dbnum，13 张表 JSONL/summary 输出；verify-mock.ps1 退 0；PR 已开
+- [ ] **C**：`compare_with=parquet` 与 surreal 并写，finalize 输出 diff；PR 已开
+- [ ] **D**：`--features ducklake` 编过，DuckLake 工厂返回骨架；PR 已开
+- [ ] **E**：`validate-compare` CLI + 13 张表的 SQL parity 脚本完整；PR 已开
+- [ ] **F**：F.1 + F.2 PR 已开；P5 backlog 中 `async fn in trait` 评估写入 v4 计划文件
+- [ ] 所有 PR URL 写入 `progress.md` v3 milestones 表
+- [ ] `findings.md` §4 补 v3 期间新发现
+
+---
+
+## 10. 与历史计划的衔接
+
+- v2 (2026-05-11-142958) 闭环 PR #11 不动；v3 新工作走独立 PR 分支
+- mission docs Phase 1 完成于 v3 Phase E（CLI + SQL validation 落地）
+- mission docs Phase 2 部分兑现（Parquet）于 v3 Phase B；DuckLake 真实写入留 v4
+- mission docs Phase 3 主体兑现于 v3 Phase C
+- mission docs Phase 4 兑现于 v3 Phase E
+- mission docs Phase 5（boolean 表）整体留 v4 或更后
+
+---
+
+## 11. v4 候选议题（不在本 v3 范围）
+
+- DuckLake 真实写入实装（引入 `duckdb` crate + `ducklake-canonical` schema + projection refresh SQL）
+- `async fn in trait` 调研报告 + 决策（如做，全 trait 迁移）
+- `inst_relate_bool` / `inst_relate_cata_bool` Phase 2 boolean canonical records
+- DrainOnly stats Mutex → atomic
+- Parquet 真正 `.parquet` 物化（替换 JSONL fallback）

--- a/docs/plans/2026-05-09-model-write-trait-followup/v3-pr-stack-review-guide.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/v3-pr-stack-review-guide.md
@@ -1,0 +1,169 @@
+# v3 PR Stack — Reviewer Guide (2026-05-12)
+
+> v3 计划完整产出：**8 个 PR** + 1 个 PR (#11) 的增量。PR 之间 stack 顺序严格，建议按时间线 / 拓扑顺序 review。本文档帮 reviewer 知道每个 PR 的范围、依赖、关键验证点。
+
+## PR 拓扑
+
+```
+                                                    feat/model-persistence-trait
+                                                    ─┬─────────────────────────────
+PR #11  (v2 trait + v3 plan increments, force-push-free)
+   │
+   ├── PR #13   docs/model-writer-storage-mission       ← docs-only, 独立
+   │
+   └── PR #14   feat/parquet-model-writer-backend       ← Phase B
+         │
+         └── PR #15   feat/model-writer-compare-mode    ← Phase C, base = #14
+               │
+               └── PR #16   feat/ducklake-backend-skeleton  ← Phase D, base = #15
+                     │
+                     └── PR #17   feat/model-writer-validation-cli  ← Phase E, base = #16
+                           │
+                           └── PR #18   refactor/take-missing-neg-carriers ← F.1, base = #17
+                                 │
+                                 └── PR #19   refactor/bridge-context        ← F.2, base = #18
+```
+
+## 推荐 Review 顺序
+
+| 顺位 | PR | Why this order |
+|---|---|---|
+| 1 | **#13** | docs-only，独立于代码 PR；先过这个让 reviewer 建立 mission 视角 |
+| 2 | **#11** | v3 plan 文件 (`v3-plan.md`) 在这里，让 reviewer 看到 v3 整体路线图 |
+| 3 | **#14** | 第一个 backend 实装（Parquet），是后续所有 backend 工作的样本 |
+| 4 | **#15** | Compare wrapper：trait 装饰器模式的例子；不动 orchestrator |
+| 5 | **#16** | DuckLake skeleton：feature-gated 占位；最小 PR，可 5 分钟过 |
+| 6 | **#17** | CLI + SQL：与 backend 实装解耦，可单独 merge |
+| 7 | **#18** | F.1 trait 接口纯化：删 `WriteBaseReport.missing_neg_carriers` |
+| 8 | **#19** | F.2 接口纯化收尾：删 `BooleanBridgeRequest::db_option` |
+
+> 顺位 6-8 可乱序 review，互相独立（虽然 git stack 上 #18 base 是 #17、#19 base 是 #18，但代码上完全正交）。
+
+## 每个 PR 的"看什么"
+
+### PR #13 — Mission docs
+- 9 份 markdown 文件，无代码
+- 检查：Phase 1 / Phase 2 boundary（mission 00）、`ducklake-canonical` schema 描述（04）、SurrealDB Cargo source 锁定（00 / 07）
+- 关键判断：mission scope 是否同意
+
+### PR #11 — v2 + v3 plan
+- v3 plan 文件 `docs/plans/2026-05-09-model-write-trait-followup/v3-plan.md`（510 行）
+- 检查：6 个 Phase 拆分、8 条架构 invariants、风险表
+- 关键判断：v3 路线图是否同意（这个一旦同意，#14..#19 都顺水推舟）
+
+### PR #14 — Parquet backend
+- 新增 `parquet.rs::ParquetModelWriterBackend` (~250 行)，挂到 `create_model_writer` 工厂
+- 关键看 trait 8 个方法实现：
+  - `init`：缓存 context + 准备 raw_root
+  - `write_base_batch`：`CanonicalRawPlanner` → 13 JSONL
+  - `persist_mesh_results`：NoOp（Phase 1 不含 mesh，mission 05）
+  - `write_inst_relate_aabb`：NoOp（base 阶段已落，避免双写）
+  - `reconcile_missing_neg`：返回 0 + `approximate=true` log
+  - `run_boolean_bridge`：skipped(`phase2_boolean_not_supported`)
+- 关键判断：Parquet 作为 "file-oriented backend, not SurrealDB replacement" 的定位是否同意
+
+### PR #15 — Compare wrapper
+- 新增 `compare.rs::CompareModelWriterBackend` (~390 行)，trait 装饰器
+- **关键设计**：装饰器零侵入 orchestrator 调用面
+- 检查：
+  - 每个方法都 primary→candidate 顺序
+  - candidate 失败立即 bail（mission 03 "fail fast, no silent fallback"）
+  - `run_boolean_bridge` 只走 primary（candidate 在 Phase 2 范围，不路由）
+  - `take_missing_neg_carriers` 由 F.1 引入，fan-out 到两边、diff log
+- 关键判断：装饰器选型 vs 修改 orchestrator 入参，哪种更好
+
+### PR #16 — DuckLake skeleton
+- ~80 行，全部 `bail!`
+- 关键看：
+  - `Cargo.toml` 新增 `ducklake = []` feature（**未引 duckdb crate**）
+  - `cargo check --features review` + `cargo check --features review,ducklake` 都得跑通
+  - `create_model_writer` 未启 feature 时 bail 信息清晰
+- 关键判断：v4 之前用 feature-gated 占位 vs 不占位，哪种更好
+
+### PR #17 — Validation CLI + SQL
+- 两部分：
+  - `aios-database model-writer diff-summary` CLI（cli_modes.rs + main.rs，~200 行）
+  - 26 个 DuckDB SQL parity 脚本 + README + 维护 generator
+- 关键看：
+  - CLI smoke：`match` exit 0、`diff --fail-on-diff` exit 2
+  - SQL 模板的 `EXCEPT` 双向 diff 逻辑
+  - Phase 1 表覆盖是否完整（13 张）
+- 关键判断：v4 typed `.parquet` 物化后能否只换 `read_json_auto` → `read_parquet`
+
+### PR #18 — F.1 take_missing_neg_carriers
+- 删 `WriteBaseReport.missing_neg_carriers` 字段
+- 加 trait method `take_missing_neg_carriers(&self) -> Result<Vec<RefnoEnum>>` (default empty)
+- Surreal/Mock 实现 drain；orchestrator 改读方式
+- 关键看：drain 幂等性断言（verify binary exit code 4）
+- 关键判断：trait method default-empty 选型
+
+### PR #19 — F.2 db_option 入 ctx
+- 删 `BooleanBridgeRequest::db_option` 字段
+- 加 `ModelWriterContext::db_option: Arc<DbOption>`
+- Surreal `run_boolean_bridge` 从 cached ctx 取 db_option
+- 关键看：trait 接口面再减一字段
+- 关键判断：是否同意 "缓存胜过新 newtype" 的选型（vs 抽 `BridgeContext` newtype）
+
+## 验证 / 编译矩阵
+
+每个 PR 都需要：
+
+```powershell
+cargo check --bin aios-database --features review
+```
+
+#16 还需要额外：
+
+```powershell
+cargo check --bin aios-database --features "review,ducklake"
+```
+
+#14 / #15 / #18 / #19 还需要 verify binary：
+
+```powershell
+pwsh -NoProfile -File docs/plans/2026-05-09-model-write-trait-followup/verify-mock.ps1
+# 等同于：
+cargo run --bin verify_model_writer_trait --features model-writer-mock
+```
+
+退出码语义：
+
+| Code | Meaning |
+|---|---|
+| 0 | PASS |
+| 1 | trait 方法返回 Err |
+| 2 | snapshot 调用计数不符 |
+| 3 | snapshot 顺序不符 |
+| 4 | 注入值未被 backend 返回（含 F.1 drain idempotent） |
+| 5 | 二次 init / cleanup-without-init 不安全 |
+| 6 | Parquet 端到端失败 |
+| 7 | Compare wrapper 端到端失败 |
+| 8 | (reserved for v4 DuckLake) |
+
+## 架构 Invariants (整个 v3 都不能破)
+
+1. DrainOnly 快路径 = baseline 模式（跳过持久化作 IO 对比基准）
+2. SurrealDB Cargo source 必须保持 `github.com/happyrust/surrealdb`
+3. `[model-writer:*]` 日志前缀契约不破
+4. 不引入新 crate 依赖（feature-gated 例外：`ducklake`）
+5. boolean 表是 Phase 2，所有非 Surreal backend 跳过
+6. Fail fast, no silent fallback（mission 03）
+7. trait 接口不泄漏 `pdms_inst::` / `Arc<DbOption>` / `Vec<RefnoEnum>`
+
+## 合并节奏建议
+
+1. **先 merge docs (#13)**：reviewer 看完 mission 后好做后面代码 review
+2. **再 merge #11 v3 plan**：让 reviewer 看到整体路线（如果不 merge plan，后续 PR review 容易跑偏）
+3. **#14 / #15 / #16 / #17 顺序 merge**：每个独立逻辑闭环
+4. **#18 / #19 可一起 merge**：两个小重构，互相独立
+5. **如果 main 有冲突**：用 GH UI `Rebase and merge` 解决，不要 force push（A.3 deferred 的原因）
+
+## v3 完成的统计
+
+- **代码改动**：~2500 行新增 + ~150 行删除（净增量；CRLF/LF 噪声让 git diff stat 看起来更大）
+- **新文件**：12 个 Rust 模块 / binary / 文档
+- **trait 方法数**：8 → 9（加 take_missing_neg_carriers）
+- **backend 数**：3 → 5（加 Parquet + Compare wrapper + DuckLake skeleton）
+- **CLI 子命令**：1 → 2（加 diff-summary）
+- **SQL parity 脚本**：0 → 26
+- **PR 数**：1 → 9 (#11 增量 + #13..#19)

--- a/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
@@ -1,0 +1,172 @@
+# v4 候选议题 (草稿，待 plannotator 正式立项)
+
+> v3 (2026-05-12) 全部 PR 化完成（#13..#19 + #11 增量），整个 trait 抽象闭环 + Parquet/Compare/DuckLake-skeleton/CLI+SQL validation/P5-backlog 二项收口落地。本文档罗列 v3 期间产生的、明确推迟到 v4 的候选议题，等用户决定优先级与拆 PR 节奏后通过 plannotator 正式立项。
+
+## 0. 状态前提
+
+- v3 PR 栈：#11 → #13 / #14 → #15 → #16 → #17 → #18 → #19，本地分支 `feat/model-persistence-trait`、`docs/model-writer-storage-mission`、`feat/parquet-model-writer-backend`、`feat/model-writer-compare-mode`、`feat/ducklake-backend-skeleton`、`feat/model-writer-validation-cli`、`refactor/take-missing-neg-carriers`、`refactor/bridge-context`
+- 整个 trait 接口面已纯化：`WriteBaseReport` 只剩 `batch_id` + `missing_neg_count`；`BooleanBridgeRequest` 只剩 `mode` + `bool_tasks`；不再泄漏 `pdms_inst::`/`RefnoEnum`/`DbOption`
+- 5 个 backend 全部到位：Surreal / DrainOnly / Parquet / DuckLake(skeleton) / Mock + Compare wrapper
+- CLI: `aios-database model-writer {validate-canonical-parquet, diff-summary}` + 26 个 DuckDB SQL parity 脚本
+- verify binary 退出码 0-7 全覆盖
+
+---
+
+## 1. 高优先级 (v4 主目标)
+
+### 1.1 DuckLake 真实写入实装
+
+**Why now**：mission `04-ducklake-writer.md` 把它列为 target architecture；v3 仅留了 feature-gated 骨架（PR #16），所有 trait 方法 `bail!`。
+
+**Scope**：
+
+- 引入 `duckdb` crate 依赖（feature-gated by `ducklake`）
+- DuckLake metadata.ducklake 路径配置（DbOption 字段：`ducklake_metadata_path` + `ducklake_data_root`，沿用现有 `transform_ducklake_metadata` 风格）
+- `init`：打开 DuckDB / attach DuckLake / 建 `ducklake-canonical` schema if absent
+- `write_base_batch` / `persist_mesh_results` / `write_inst_relate_aabb`：transaction-style upsert 到 13 张 raw 表
+- `cleanup` / `reconcile_missing_neg`：SQL DELETE + missing-key 扫描
+- `finalize`：projection refresh SQL（per mission `04` §Table strategy）
+- Verify binary 加 exit code 8 = ducklake path fail
+- Compare 模式可挂 ducklake 作为 candidate（trait 已支持）
+
+**Non-goals**：
+
+- 不替代 SurrealDB 主写入（仍是默认）
+- 不重写 v3 已落地的 Parquet sink（JSONL fallback 仍保留作为 export 备份）
+
+**预估**：~600 行 Rust + ~150 行 SQL + DbOption 字段。**风险**：duckdb crate 在 Windows 上 build 重，需要 LLVM/MSVC；mission 00 §Non-goals 明确 SurrealDB 源不能改。
+
+---
+
+### 1.2 Parquet 真正 `.parquet` 物化（替换 JSONL fallback）
+
+**Why now**：mission `05-parquet-writer.md` §Phase boundary 明确 JSONL 只是 v3 fallback；CLI E.2 的 26 个 SQL parity 脚本目前用 `read_json_auto`，typed `.parquet` 直接换成 `read_parquet` 性能 + schema 强度都提升。
+
+**Scope**：
+
+- 引入 `arrow` + `parquet` crate（feature-gated by `parquet-canonical`，避免污染默认构建）
+- `CanonicalRawTable` per-table Arrow schema 静态定义（用 `arrow_schema::Schema`）
+- `CanonicalParquetWriter::write_raw_batch` 走 `parquet::arrow::ArrowWriter`，按现有目录 layout 落 `.parquet`
+- 旧 JSONL 路径保留为兼容回退（`--parquet-format jsonl|parquet`，默认 parquet）
+- SQL 脚本 `read_json_auto(...)` 改为 `read_parquet(...)`（一行替换）
+- Verify binary 加 schema 断言：每张表的列类型与 canonical_records.rs 字段一致
+
+**Non-goals**：
+
+- 不引入 polars
+- 不改 canonical_records.rs schema 定义（仅 derive Parquet schema）
+
+**预估**：~400 行 + arrow/parquet crate 依赖。
+
+---
+
+## 2. 中优先级
+
+### 2.1 `inst_relate_bool` / `inst_relate_cata_bool` Phase 2 boolean canonical records
+
+**Why now**：mission `00` + `08` 把 boolean 表明确推到 Phase 2；v3 所有 backend 的 `run_boolean_bridge` 现在都跳过这两张表（Parquet/Compare 返回 `phase2_boolean_not_supported` skip log）。
+
+**Scope**：
+
+- canonical_records.rs 加 `RawInstRelateBoolRecord` + `RawInstRelateCataBoolRecord`
+- `CanonicalRawTable` enum 加两个变体（注意 v3 `all_phase1()` 是 Phase 1 only，新建 `all_phase2()` 或合并）
+- 所有 backend `run_boolean_bridge` 改写：成功路径落 canonical raw records；Parquet sink 多写 2 张 JSONL/parquet 表
+- E.2 SQL 脚本目录扩 `scripts/sql/model-writer-parity-phase2/`
+- verify binary 加 phase 2 fixture
+
+**Non-goals**：
+
+- 不动 boolean worker 内部 SQL；只在 trait boundary 多落一层 canonical
+
+**预估**：~250 行 + 4 个 SQL 脚本。
+
+---
+
+### 2.2 `async fn in trait` 调研报告
+
+**Why now**：v3 全程用 `#[async_trait]`，每个 trait 方法都过 `Pin<Box<dyn Future>>`，hot path 上有开销。Rust 1.75+ nightly 已稳定 native AFIT。
+
+**Scope** (Documentation-only, not code change)：
+
+- 在 `docs/development/model-writer-storage/` 加 `09-async-trait-migration.md`
+- 内容：调研 native AFIT vs async_trait 对 `Send + Sync + dyn` 的兼容性、性能差异、迁移成本
+- 决策：迁移 / 不迁移 / 部分迁移；如果决策迁移则在 v4 后续 PR 实施
+
+**Non-goals**：
+
+- 不立即迁移（先调研）
+
+**预估**：1 份文档 + 任选 1 个 trait 方法做 benchmark fixture。
+
+---
+
+### 2.3 DrainOnly stats `Mutex` → atomic
+
+**Why now**：v2 N-5；DrainOnly 是 baseline，stats 走 `Mutex<DrainOnlyStats>`，hot path 上 lock 开销稍大。
+
+**Scope**：
+
+- `DrainOnlyStats` 字段全改 `AtomicU64` / `AtomicUsize`
+- `print_summary` 用 `load(Ordering::Relaxed)` 读
+- 所有 trait 方法的 stats 累加改 `fetch_add`
+
+**Non-goals**：
+
+- 不动 DrainOnly 快路径（v2 invariant 锁定）
+
+**预估**：~80 行。**小 PR**。
+
+---
+
+## 3. 低优先级（视情况打包到 v4 或更后）
+
+### 3.1 PR #11 合并时的 rebase 处理（A.3 deferred）
+
+- 当前 `feat/model-persistence-trait` 落后 main 13 commits、领先 18 commits（含 v3 increments）
+- 推荐：reviewer 通过 GH UI 选 `Rebase and merge`，避免 force push 污染评论
+- 若合并冲突过大，转 worktree 本地 rebase + force push（需用户授权）
+
+### 3.2 9 个 mission docs 的格式标准化
+
+- 部分 docs 还是 Markdown 草稿，可能加 frontmatter / TOC / cross-link
+- 不阻塞功能，纯文档美化
+
+### 3.3 BridgeContext 升级到更彻底拆分
+
+- v3 F.2 把 `Arc<DbOption>` 移到 `ModelWriterContext`，本质是 "把字段从 request 搬到 context"
+- 真正彻底的拆分：抽 `BridgeContext { use_surrealdb, defer_db_write, bool_worker_batch_size }`，让 boolean worker 函数签名也不再依赖 `Arc<DbOption>`
+- v3 找了简化路径（缓存而非抽 newtype），如果 v4 要做 native AFIT 迁移、或要把 boolean worker 模块化，可能值得重新拆
+
+---
+
+## 4. v3 残余事项不在 v4 范围
+
+- `_gen_sql.ps1` 重生成时的 here-string 行为：已修正模板但保留为维护工具，不入 production path
+- worktree 卫生（本轮新建 7 个 worktree 已 push 到 origin；可随时 `git worktree remove .worktrees/<name>` 回收磁盘）
+
+---
+
+## 5. v4 拆 PR 建议节奏（草稿）
+
+```
+v4 PR #1   docs(model-writer-storage): 09-async-trait-migration.md (调研)
+v4 PR #2   refactor(model-writer): DrainOnly stats Mutex → atomic   (small)
+v4 PR #3   feat(model-writer): Parquet typed materialization        (B.x v2)
+v4 PR #4   feat(model-writer): DuckLake real implementation         (主目标)
+v4 PR #5   feat(model-writer): Phase 2 boolean canonical records    (E2.5)
+```
+
+PR #4 是 v4 主目标，依赖 #3（typed parquet 让 SQL parity 更强）。其余可并行。
+
+---
+
+## 6. 下一步建议
+
+1. 等 v3 PR 栈（#13..#19）逐步 review + merge；任何 review feedback 都先回到对应 v3 PR 处理
+2. PR #11 通过 GH UI `Rebase and merge` 解决 A.3
+3. v3 全部 merge 后，把本文件转成 `v4-plan.md` 通过 plannotator 提交审核，按 §5 顺序立项
+
+> 本文件是草稿，**不是** plannotator approved 计划。正式执行前需要：
+> 1. 用户确认 §1-§3 的优先级
+> 2. 用户拍板 §5 的拆分节奏
+> 3. 通过 plannotator submit_plan 走 v4 审核流程

--- a/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
@@ -82,7 +82,9 @@
 
 ---
 
-### 2.2 `async fn in trait` 调研报告
+### 2.2 `async fn in trait` 调研报告 ✅ DONE (PR #21 — decision: NO migrate)
+
+**Status**: 2026-05-12 完成。PR #21 (`docs/async-fn-in-trait-research`)，base = `refactor/drain-only-stats-atomic` (PR #20)，docs-only。结论：**v4 不迁移**。理由：native AFIT 在 Rust 1.97-nightly 仍不 `dyn`-compatible；项目通过 `Arc<dyn ModelWriterBackend>` 全程走 dyn 路径；迁移需要 `trait-variant` 新依赖或拆分 trait（surface ×2），dyn 路径仍 box future、零 perf 收益。详见 `docs/development/model-writer-storage/09-async-trait-migration.md`。Reconsider 触发：`dyn_compatible_for_dispatch` 稳定（rust-lang/rust#107011）。
 
 **Why now**：v3 全程用 `#[async_trait]`，每个 trait 方法都过 `Pin<Box<dyn Future>>`，hot path 上有开销。Rust 1.75+ nightly 已稳定 native AFIT。
 

--- a/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
@@ -100,7 +100,9 @@
 
 ---
 
-### 2.3 DrainOnly stats `Mutex` → atomic
+### 2.3 DrainOnly stats `Mutex` → atomic ✅ DONE (PR #20)
+
+**Status**: 2026-05-12 完成。PR #20 (`refactor/drain-only-stats-atomic`)，base = `refactor/bridge-context` (PR #19)，单文件改动 `drain_only.rs`，cargo check + verify-mock 均 PASS。`run_drain_only_sink` 主路径未动（仍 stack stats + plain usize +=），仅 trait-routed 那条路改 atomic。
 
 **Why now**：v2 N-5；DrainOnly 是 baseline，stats 走 `Mutex<DrainOnlyStats>`，hot path 上 lock 开销稍大。
 

--- a/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
+++ b/docs/plans/2026-05-09-model-write-trait-followup/v4-candidates.md
@@ -62,7 +62,25 @@
 
 ## 2. 中优先级
 
-### 2.1 `inst_relate_bool` / `inst_relate_cata_bool` Phase 2 boolean canonical records
+### 2.1 `inst_relate_bool` / `inst_relate_cata_bool` Phase 2 boolean canonical records ⚠️ PARTIAL (PR #22 schema scaffold only)
+
+**Status**: 2026-05-12 schema-only 部分完成。PR #22 (`feat/phase2-boolean-canonical-schema`)，base = `docs/async-fn-in-trait-research` (PR #21)，单文件 `canonical_records.rs` ~70 行。
+
+实施时发现 `manifold_bool.rs` 的 boolean worker 直接 emit SQL 进 SurrealDB，`BoolWorkerReport` 只有聚合计数没有 per-row data；让所有 backend `run_boolean_bridge` 落 canonical 需要先重构 worker 暴露 per-row 输出，超出 ~250 行预算。
+
+**实际落地**（PR #22）：
+- 加 `CanonicalRawTable::RawInstRelateBool` / `RawInstRelateCataBool` 枚举变体
+- 加 `RawInstRelateBoolRecord` / `RawInstRelateCataBoolRecord` struct（字段从 v3 Surreal SQL 反推）
+- 加 `phase2_limitation()` + `all_phase2()` 方法
+- `CanonicalRawRowCounts::set` 回退到 phase2_limitation
+- `CanonicalRawBatch` **不动**（不加 Vec 字段，否则强迫所有 backend flush 实际行）
+
+**留到 v5+**（PR 拆分清单）：
+1. 给 `CanonicalRawBatch` 加 `inst_relate_bool` / `inst_relate_cata_bool` Vec 字段
+2. 重构 `manifold_bool.rs` 把 worker per-row 输出 expose 为 channel 或 BoolWorkerReport 扩展
+3. Surreal/Parquet/Compare 三个 backend 收集 boolean rows + finalize flush
+4. `scripts/sql/model-writer-parity-phase2/` 新建 + 4 个 SQL
+5. verify binary 加 Phase 2 fixture
 
 **Why now**：mission `00` + `08` 把 boolean 表明确推到 Phase 2；v3 所有 backend 的 `run_boolean_bridge` 现在都跳过这两张表（Parquet/Compare 返回 `phase2_boolean_not_supported` skip log）。
 

--- a/src/bin/verify_model_writer_trait.rs
+++ b/src/bin/verify_model_writer_trait.rs
@@ -1,0 +1,167 @@
+//! ModelWriterBackend trait 契约验证 binary。
+//!
+//! 用 `RecordingBackend`（feature `model-writer-mock`）跑一次完整调用链，
+//! 断言 8 个 trait 方法按预期顺序被调用，每次调用入参符合预期。
+//!
+//! 用法：
+//! ```powershell
+//! cargo run --bin verify_model_writer_trait --features model-writer-mock
+//! ```
+//!
+//! 退出码：
+//!   0 — 通过
+//!   1 — trait 方法返回 Err
+//!   2 — snapshot 调用计数不符
+//!   3 — snapshot 顺序不符
+
+#![cfg(feature = "model-writer-mock")]
+
+use std::collections::HashMap;
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use aios_core::geometry::ShapeInstancesData;
+use aios_database::fast_model::gen_model::mesh_generate::MeshResult;
+use aios_database::fast_model::gen_model::model_writer::{
+    BaseInstanceBatch, BooleanBridgeRequest, CleanupRequest, FinalizeRequest, InstRelateAabbBatch,
+    MeshResultBatch, ModelWriterBackend, ModelWriterContext, ReconcileRequest, RecordingBackend,
+};
+use aios_database::options::{BooleanPipelineMode, ModelWriterMode};
+use dashmap::DashMap;
+use parry3d::bounding_volume::Aabb;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> ExitCode {
+    let backend = Arc::new(RecordingBackend::default());
+
+    let context = ModelWriterContext {
+        project_name: "verify-fixture".to_string(),
+        use_surrealdb: true,
+        defer_db_write: false,
+        mode: ModelWriterMode::Surreal,
+    };
+
+    let shape_insts = ShapeInstancesData::default();
+    let mesh_aabb_map: DashMap<String, Aabb> = DashMap::new();
+    let mesh_pts_map: DashMap<u64, String> = DashMap::new();
+    let mesh_results: HashMap<u64, MeshResult> = HashMap::new();
+
+    if let Err(e) = backend.init(&context).await {
+        eprintln!("[verify] FAIL: init: {}", e);
+        return ExitCode::from(1);
+    }
+
+    if let Err(e) = backend.cleanup(CleanupRequest { seed_refnos: &[] }).await {
+        eprintln!("[verify] FAIL: cleanup: {}", e);
+        return ExitCode::from(1);
+    }
+
+    if let Err(e) = backend
+        .write_base_batch(BaseInstanceBatch {
+            batch_id: 1,
+            shape_insts: &shape_insts,
+            mesh_aabb_map: &mesh_aabb_map,
+            replace_exist: false,
+            write_inst_relate_aabb: false,
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: write_base_batch: {}", e);
+        return ExitCode::from(1);
+    }
+
+    if let Err(e) = backend
+        .persist_mesh_results(MeshResultBatch {
+            batch_id: 1,
+            mesh_results: &mesh_results,
+            mesh_aabb_map: &mesh_aabb_map,
+            mesh_pts_map: &mesh_pts_map,
+            file_mesh_state: false,
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: persist_mesh_results: {}", e);
+        return ExitCode::from(1);
+    }
+
+    if let Err(e) = backend
+        .write_inst_relate_aabb(InstRelateAabbBatch {
+            batch_id: 1,
+            shape_insts: &shape_insts,
+            mesh_results: &mesh_results,
+            mesh_aabb_map: &mesh_aabb_map,
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: write_inst_relate_aabb: {}", e);
+        return ExitCode::from(1);
+    }
+
+    if let Err(e) = backend
+        .reconcile_missing_neg(ReconcileRequest {
+            all_refnos: &[],
+            candidate_carriers: &[],
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: reconcile_missing_neg: {}", e);
+        return ExitCode::from(1);
+    }
+
+    if let Err(e) = backend
+        .run_boolean_bridge(BooleanBridgeRequest {
+            mode: BooleanPipelineMode::DbLegacy,
+            db_option: Arc::new(aios_core::options::DbOption::default()),
+            bool_tasks: Vec::new(),
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: run_boolean_bridge: {}", e);
+        return ExitCode::from(1);
+    }
+
+    if let Err(e) = backend.finalize(FinalizeRequest::default()).await {
+        eprintln!("[verify] FAIL: finalize: {}", e);
+        return ExitCode::from(1);
+    }
+
+    let snapshot = backend.snapshot();
+    let expected_prefixes = [
+        "init:",
+        "cleanup:",
+        "write_base_batch:",
+        "persist_mesh_results:",
+        "write_inst_relate_aabb:",
+        "reconcile_missing_neg:",
+        "run_boolean_bridge:",
+        "finalize:",
+    ];
+
+    if snapshot.len() != expected_prefixes.len() {
+        eprintln!(
+            "[verify] FAIL: 调用计数不符 expected={} got={}",
+            expected_prefixes.len(),
+            snapshot.len()
+        );
+        for line in &snapshot {
+            eprintln!("  - {}", line);
+        }
+        return ExitCode::from(2);
+    }
+
+    for (idx, prefix) in expected_prefixes.iter().enumerate() {
+        if !snapshot[idx].starts_with(prefix) {
+            eprintln!(
+                "[verify] FAIL: 第 {} 步预期前缀 `{}`, 实得 `{}`",
+                idx, prefix, snapshot[idx]
+            );
+            return ExitCode::from(3);
+        }
+    }
+
+    println!("[verify] PASS — 8 个 trait 方法按预期顺序被调用");
+    for (idx, line) in snapshot.iter().enumerate() {
+        println!("  [{}] {}", idx + 1, line);
+    }
+    ExitCode::SUCCESS
+}

--- a/src/bin/verify_model_writer_trait.rs
+++ b/src/bin/verify_model_writer_trait.rs
@@ -13,6 +13,8 @@
 //!   1 — trait 方法返回 Err
 //!   2 — snapshot 调用计数不符
 //!   3 — snapshot 顺序不符
+//!   4 — 注入值未被 backend 返回
+//!   5 — 二次 init / cleanup-without-init 安全性断言失败
 
 #![cfg(feature = "model-writer-mock")]
 
@@ -20,6 +22,7 @@ use std::collections::HashMap;
 use std::process::ExitCode;
 use std::sync::Arc;
 
+use aios_core::RefnoEnum;
 use aios_core::geometry::ShapeInstancesData;
 use aios_database::fast_model::gen_model::mesh_generate::MeshResult;
 use aios_database::fast_model::gen_model::model_writer::{
@@ -30,9 +33,18 @@ use aios_database::options::{BooleanPipelineMode, ModelWriterMode};
 use dashmap::DashMap;
 use parry3d::bounding_volume::Aabb;
 
+const INJECTED_RECONCILE: usize = 42;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let backend = Arc::new(RecordingBackend::default());
+
+    let injected_carriers: Vec<RefnoEnum> = vec![RefnoEnum::default(), RefnoEnum::default()];
+    *backend
+        .injected_reconcile_inserted
+        .lock()
+        .expect("recording lock") = INJECTED_RECONCILE;
+    *backend.injected_missing_neg.lock().expect("recording lock") = injected_carriers.clone();
 
     let context = ModelWriterContext {
         project_name: "verify-fixture".to_string(),
@@ -50,13 +62,18 @@ async fn main() -> ExitCode {
         eprintln!("[verify] FAIL: init: {}", e);
         return ExitCode::from(1);
     }
+    // 二次 init 必须安全（RecordingBackend 内部应当幂等记录，无 panic / Err）
+    if let Err(e) = backend.init(&context).await {
+        eprintln!("[verify] FAIL: second init should be safe: {}", e);
+        return ExitCode::from(5);
+    }
 
     if let Err(e) = backend.cleanup(CleanupRequest { seed_refnos: &[] }).await {
         eprintln!("[verify] FAIL: cleanup: {}", e);
         return ExitCode::from(1);
     }
 
-    if let Err(e) = backend
+    let base_report = match backend
         .write_base_batch(BaseInstanceBatch {
             batch_id: 1,
             shape_insts: &shape_insts,
@@ -66,8 +83,22 @@ async fn main() -> ExitCode {
         })
         .await
     {
-        eprintln!("[verify] FAIL: write_base_batch: {}", e);
-        return ExitCode::from(1);
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[verify] FAIL: write_base_batch: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    if base_report.missing_neg_count != injected_carriers.len()
+        || base_report.missing_neg_carriers.len() != injected_carriers.len()
+    {
+        eprintln!(
+            "[verify] FAIL: injected missing_neg not honored: count={} carriers={} expected={}",
+            base_report.missing_neg_count,
+            base_report.missing_neg_carriers.len(),
+            injected_carriers.len()
+        );
+        return ExitCode::from(4);
     }
 
     if let Err(e) = backend
@@ -97,15 +128,25 @@ async fn main() -> ExitCode {
         return ExitCode::from(1);
     }
 
-    if let Err(e) = backend
+    let inserted = match backend
         .reconcile_missing_neg(ReconcileRequest {
             all_refnos: &[],
             candidate_carriers: &[],
         })
         .await
     {
-        eprintln!("[verify] FAIL: reconcile_missing_neg: {}", e);
-        return ExitCode::from(1);
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[verify] FAIL: reconcile_missing_neg: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    if inserted != INJECTED_RECONCILE {
+        eprintln!(
+            "[verify] FAIL: injected_reconcile_inserted not honored: got={} expected={}",
+            inserted, INJECTED_RECONCILE
+        );
+        return ExitCode::from(4);
     }
 
     if let Err(e) = backend
@@ -128,6 +169,7 @@ async fn main() -> ExitCode {
     let snapshot = backend.snapshot();
     let expected_prefixes = [
         "init:",
+        "init:", // second init recorded — mock 应记录两次
         "cleanup:",
         "write_base_batch:",
         "persist_mesh_results:",
@@ -159,7 +201,40 @@ async fn main() -> ExitCode {
         }
     }
 
-    println!("[verify] PASS — 8 个 trait 方法按预期顺序被调用");
+    // 反例：snapshot 不能包含计划外的方法名（防止 trait 误增方法或 mock 漏改）
+    let allowed_methods = [
+        "init",
+        "cleanup",
+        "write_base_batch",
+        "persist_mesh_results",
+        "write_inst_relate_aabb",
+        "reconcile_missing_neg",
+        "run_boolean_bridge",
+        "finalize",
+    ];
+    for line in &snapshot {
+        let method = line.split(':').next().unwrap_or("");
+        if !allowed_methods.contains(&method) {
+            eprintln!("[verify] FAIL: snapshot 含未预期方法 `{}`", method);
+            return ExitCode::from(3);
+        }
+    }
+
+    // 二次 backend：cleanup-without-init 也必须安全（对应 cli_modes 历史路径）
+    let backend2 = Arc::new(RecordingBackend::default());
+    if let Err(e) = backend2.cleanup(CleanupRequest { seed_refnos: &[] }).await {
+        eprintln!(
+            "[verify] FAIL: cleanup-without-init should be safe on mock: {}",
+            e
+        );
+        return ExitCode::from(5);
+    }
+
+    println!(
+        "[verify] PASS — 9 个 trait 调用按预期记录（含二次 init），注入值 reconcile={} missing_neg={} 均被 honored",
+        INJECTED_RECONCILE,
+        injected_carriers.len()
+    );
     for (idx, line) in snapshot.iter().enumerate() {
         println!("  [{}] {}", idx + 1, line);
     }

--- a/src/cli_modes.rs
+++ b/src/cli_modes.rs
@@ -1737,9 +1737,18 @@ pub async fn run_regen_model(
 
     // 统一走 trait：DrainOnly backend 的 cleanup 是 NoOp，确保压测模式不会误删数据；
     // Surreal backend 内部仍按既有顺序清理 legacy 模型关系 + refno_relations 扁平表。
+    //
+    // Lifecycle 契约：init → cleanup → ... → finalize。
+    // SurrealDB 侧 `init_model_tables` 走 DEFINE TABLE 语义，幂等可重复调；保留 init
+    // 是为了让未来需要 init 副作用的 backend（Parquet/DuckLake/...）不会被静默绕过。
     let model_writer = aios_database::fast_model::gen_model::model_writer::create_model_writer(
         &db_option_override,
     )?;
+    let writer_context =
+        aios_database::fast_model::gen_model::model_writer::ModelWriterContext::from_db_option(
+            &db_option_override,
+        );
+    model_writer.init(&writer_context).await?;
     model_writer
         .cleanup(
             aios_database::fast_model::gen_model::model_writer::CleanupRequest {

--- a/src/cli_modes.rs
+++ b/src/cli_modes.rs
@@ -1680,22 +1680,17 @@ pub async fn run_regen_model(
     }
     let target_refnos = collect_regen_target_refnos(config).await?;
 
-    if db_option_override.model_writer_mode.writes_to_surreal() {
-        // 先清理 legacy 模型关系（含 inst_relate / geo_relate / tubi_relate），
-        // 再清理 refno_relations 扁平表，避免 regen 后导出仍读到历史 tubi 脏数据。
-        let model_writer = aios_database::fast_model::gen_model::model_writer::create_model_writer(
-            &db_option_override,
-        )?;
-        model_writer
-            .cleanup(
-                aios_database::fast_model::gen_model::model_writer::CleanupRequest {
-                    seed_refnos: &target_refnos,
-                },
-            )
-            .await?;
-    } else {
-        println!("   - drain-only 压测模式：跳过 regen cleanup，避免删除现有 SurrealDB 模型数据");
-    }
+    // 统一走 trait：DrainOnly backend 的 cleanup 是 NoOp，确保压测模式不会误删数据；
+    // Surreal backend 内部仍按既有顺序清理 legacy 模型关系 + refno_relations 扁平表。
+    let model_writer =
+        aios_database::fast_model::gen_model::model_writer::create_model_writer(&db_option_override)?;
+    model_writer
+        .cleanup(
+            aios_database::fast_model::gen_model::model_writer::CleanupRequest {
+                seed_refnos: &target_refnos,
+            },
+        )
+        .await?;
 
     // 4.1 从目标 refnos 推导 dbnum，覆盖配置文件中的 manual_db_nums
     if !target_refnos.is_empty() {

--- a/src/cli_modes.rs
+++ b/src/cli_modes.rs
@@ -1683,12 +1683,16 @@ pub async fn run_regen_model(
     if db_option_override.model_writer_mode.writes_to_surreal() {
         // 先清理 legacy 模型关系（含 inst_relate / geo_relate / tubi_relate），
         // 再清理 refno_relations 扁平表，避免 regen 后导出仍读到历史 tubi 脏数据。
-        aios_database::fast_model::gen_model::pdms_inst::pre_cleanup_for_regen(&target_refnos)
+        let model_writer = aios_database::fast_model::gen_model::model_writer::create_model_writer(
+            &db_option_override,
+        )?;
+        model_writer
+            .cleanup(
+                aios_database::fast_model::gen_model::model_writer::CleanupRequest {
+                    seed_refnos: &target_refnos,
+                },
+            )
             .await?;
-        aios_database::fast_model::gen_model::pdms_inst_surreal::pre_cleanup_for_regen_surreal(
-            &target_refnos,
-        )
-        .await?;
     } else {
         println!("   - drain-only 压测模式：跳过 regen cleanup，避免删除现有 SurrealDB 模型数据");
     }

--- a/src/cli_modes.rs
+++ b/src/cli_modes.rs
@@ -15,6 +15,10 @@ use aios_database::fast_model::export_model::export_obj::export_obj_for_refnos;
 use aios_database::fast_model::export_model::export_room_instances::{
     RoomComputeValidationCase, RoomComputeValidationFixture,
 };
+use aios_database::fast_model::gen_model::model_writer::{
+    CanonicalParquetTableSummary, CanonicalParquetWriter, CanonicalParquetWriterConfig,
+    CanonicalRawPlanner,
+};
 use aios_database::options::DbOptionExt;
 use aios_database::perf_timer::{PerfReport, PerfTimer};
 use parry3d::bounding_volume::BoundingVolume;
@@ -264,6 +268,58 @@ impl ExportConfig {
         println!("   - 全库导出: {}", self.run_all_dbnos);
         println!("   - 按 SITE 拆分: {}", self.split_by_site);
     }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CanonicalParquetValidationReport {
+    pub status: &'static str,
+    pub summary_path: String,
+    pub raw_root: String,
+    pub project_name: String,
+    pub dbnum: u32,
+    pub batch_id: u64,
+    pub total_rows: usize,
+    pub tables: Vec<CanonicalParquetTableSummary>,
+}
+
+/// Non-production CLI validation entry for the canonical raw planner plus the
+/// canonical Parquet(JSONL fallback) writer scaffold.
+///
+/// This intentionally builds an empty `ShapeInstancesData` fixture and never
+/// enters the default `gen_model`/SurrealDB writer path.
+pub fn validate_canonical_parquet_writer_mode(
+    output_dir: &Path,
+    project_name: &str,
+    dbnum: u32,
+    batch_id: u64,
+) -> Result<CanonicalParquetValidationReport> {
+    let shape_insts = aios_core::geometry::ShapeInstancesData::default();
+    let planner = CanonicalRawPlanner;
+    let batch = planner.plan_shape_instances(&shape_insts);
+    let writer = CanonicalParquetWriter::new(CanonicalParquetWriterConfig {
+        output_dir: output_dir.to_path_buf(),
+        project_name: project_name.to_string(),
+        dbnum,
+    });
+    let summary = writer.write_raw_batch(batch_id, &batch)?;
+    let summary_path = output_dir
+        .join("model_writer_storage")
+        .join("summary")
+        .join(format!("project_name={project_name}"))
+        .join(format!("dbnum={dbnum}"))
+        .join(format!("batch_{batch_id}.json"));
+    let total_rows = summary.tables.iter().map(|table| table.rows).sum();
+
+    Ok(CanonicalParquetValidationReport {
+        status: "ok",
+        summary_path: summary_path.display().to_string(),
+        raw_root: summary.raw_root,
+        project_name: summary.project_name,
+        dbnum: summary.dbnum,
+        batch_id: summary.batch_id,
+        total_rows,
+        tables: summary.tables,
+    })
 }
 
 fn parse_length_unit(unit: &str) -> LengthUnit {
@@ -1682,8 +1738,9 @@ pub async fn run_regen_model(
 
     // 统一走 trait：DrainOnly backend 的 cleanup 是 NoOp，确保压测模式不会误删数据；
     // Surreal backend 内部仍按既有顺序清理 legacy 模型关系 + refno_relations 扁平表。
-    let model_writer =
-        aios_database::fast_model::gen_model::model_writer::create_model_writer(&db_option_override)?;
+    let model_writer = aios_database::fast_model::gen_model::model_writer::create_model_writer(
+        &db_option_override,
+    )?;
     model_writer
         .cleanup(
             aios_database::fast_model::gen_model::model_writer::CleanupRequest {

--- a/src/cli_modes.rs
+++ b/src/cli_modes.rs
@@ -272,6 +272,9 @@ impl ExportConfig {
 
 #[derive(Debug, serde::Serialize)]
 pub struct CanonicalParquetValidationReport {
+    pub backend: &'static str,
+    pub format: &'static str,
+    pub limitation: &'static str,
     pub status: &'static str,
     pub summary_path: String,
     pub raw_root: String,
@@ -302,22 +305,18 @@ pub fn validate_canonical_parquet_writer_mode(
         dbnum,
     });
     let summary = writer.write_raw_batch(batch_id, &batch)?;
-    let summary_path = output_dir
-        .join("model_writer_storage")
-        .join("summary")
-        .join(format!("project_name={project_name}"))
-        .join(format!("dbnum={dbnum}"))
-        .join(format!("batch_{batch_id}.json"));
-    let total_rows = summary.tables.iter().map(|table| table.rows).sum();
 
     Ok(CanonicalParquetValidationReport {
+        backend: summary.backend,
+        format: summary.format,
+        limitation: summary.limitation,
         status: "ok",
-        summary_path: summary_path.display().to_string(),
+        summary_path: summary.summary_path,
         raw_root: summary.raw_root,
         project_name: summary.project_name,
         dbnum: summary.dbnum,
         batch_id: summary.batch_id,
-        total_rows,
+        total_rows: summary.total_rows,
         tables: summary.tables,
     })
 }

--- a/src/fast_model/gen_model/canonical_records.rs
+++ b/src/fast_model/gen_model/canonical_records.rs
@@ -1,0 +1,497 @@
+use std::collections::{BTreeMap, HashMap};
+
+use aios_core::geometry::{GeoBasicType, ShapeInstancesData};
+use aios_core::{gen_aabb_hash, gen_plant_transform_hash, gen_string_hash};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum CanonicalRawTable {
+    RawInstInfo,
+    RawInstRelate,
+    RawInstGeo,
+    RawGeoRelate,
+    RawTubiInfo,
+    RawTubiRelate,
+    RawNegRelate,
+    RawNgmrRelate,
+    RawAabb,
+    RawTrans,
+    RawVec3,
+    RawInstRelateAabb,
+    RawRefnoAssocIndex,
+}
+
+impl CanonicalRawTable {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RawInstInfo => "raw_inst_info",
+            Self::RawInstRelate => "raw_inst_relate",
+            Self::RawInstGeo => "raw_inst_geo",
+            Self::RawGeoRelate => "raw_geo_relate",
+            Self::RawTubiInfo => "raw_tubi_info",
+            Self::RawTubiRelate => "raw_tubi_relate",
+            Self::RawNegRelate => "raw_neg_relate",
+            Self::RawNgmrRelate => "raw_ngmr_relate",
+            Self::RawAabb => "raw_aabb",
+            Self::RawTrans => "raw_trans",
+            Self::RawVec3 => "raw_vec3",
+            Self::RawInstRelateAabb => "raw_inst_relate_aabb",
+            Self::RawRefnoAssocIndex => "raw_refno_assoc_index",
+        }
+    }
+
+    pub fn phase1_limitation(self) -> Option<&'static str> {
+        match self {
+            Self::RawRefnoAssocIndex => Some(
+                "Phase 1 retains refno_assoc_index as a raw table for delete/index parity, but runtime materialization is intentionally disabled.",
+            ),
+            _ => None,
+        }
+    }
+
+    pub const fn all_phase1() -> &'static [Self] {
+        &[
+            Self::RawInstInfo,
+            Self::RawInstRelate,
+            Self::RawInstGeo,
+            Self::RawGeoRelate,
+            Self::RawTubiInfo,
+            Self::RawTubiRelate,
+            Self::RawNegRelate,
+            Self::RawNgmrRelate,
+            Self::RawAabb,
+            Self::RawTrans,
+            Self::RawVec3,
+            Self::RawInstRelateAabb,
+            Self::RawRefnoAssocIndex,
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CanonicalRawRowCounts {
+    counts: BTreeMap<String, usize>,
+    limitations: BTreeMap<String, Option<String>>,
+}
+
+impl CanonicalRawRowCounts {
+    pub fn set(&mut self, table: CanonicalRawTable, count: usize) {
+        self.counts.insert(table.as_str().to_owned(), count);
+        self.limitations.insert(
+            table.as_str().to_owned(),
+            table.phase1_limitation().map(str::to_owned),
+        );
+    }
+
+    pub fn get(&self, table: CanonicalRawTable) -> usize {
+        self.counts.get(table.as_str()).copied().unwrap_or(0)
+    }
+
+    pub fn as_map(&self) -> &BTreeMap<String, usize> {
+        &self.counts
+    }
+
+    pub fn limitation(&self, table: CanonicalRawTable) -> Option<&str> {
+        self.limitations
+            .get(table.as_str())
+            .and_then(|value| value.as_deref())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalRawPayload {
+    pub surreal_json: Option<String>,
+    pub limitation: Option<String>,
+}
+
+impl CanonicalRawPayload {
+    fn surreal_json(value: String) -> Self {
+        Self {
+            surreal_json: Some(value),
+            limitation: None,
+        }
+    }
+
+    fn placeholder(reason: &'static str) -> Self {
+        Self {
+            surreal_json: None,
+            limitation: Some(reason.to_owned()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawInstInfoRecord {
+    pub refno: String,
+    pub inst_id: String,
+    pub inst_relate_id: String,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawInstRelateRecord {
+    pub refno: String,
+    pub pe_id: String,
+    pub inst_id: String,
+    pub relation_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawInstGeoRecord {
+    pub owner_refno: String,
+    pub inst_id: String,
+    pub geom_refno: String,
+    pub geo_hash: u64,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawGeoRelateRecord {
+    pub relation_id: u64,
+    pub inst_id: String,
+    pub geo_hash: u64,
+    pub geom_refno: String,
+    pub geo_type: String,
+    pub trans_id: u64,
+    pub visible: bool,
+    pub pts_ids: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawTubiInfoRecord {
+    pub tubi_id: String,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawTubiRelateRecord {
+    pub refno: String,
+    pub branch_id: String,
+    pub aabb_id: Option<u64>,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawDependencyRelateRecord {
+    pub carrier_refno: String,
+    pub target_refno: String,
+    pub geom_refno: Option<String>,
+    pub relation_kind: String,
+    pub geo_relate_ids: Vec<u64>,
+    pub pending: bool,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawAabbRecord {
+    pub aabb_id: u64,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawTransRecord {
+    pub trans_id: u64,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawVec3Record {
+    pub vec3_id: u64,
+    pub payload: CanonicalRawPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawInstRelateAabbRecord {
+    pub refno: String,
+    pub relation_id: String,
+    pub aabb_id: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawRefnoAssocIndexRecord {
+    pub refno: String,
+    pub associated_records: Vec<String>,
+    pub limitation: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CanonicalRawBatch {
+    pub inst_info: Vec<RawInstInfoRecord>,
+    pub inst_relate: Vec<RawInstRelateRecord>,
+    pub inst_geo: Vec<RawInstGeoRecord>,
+    pub geo_relate: Vec<RawGeoRelateRecord>,
+    pub tubi_info: Vec<RawTubiInfoRecord>,
+    pub tubi_relate: Vec<RawTubiRelateRecord>,
+    pub neg_relate: Vec<RawDependencyRelateRecord>,
+    pub ngmr_relate: Vec<RawDependencyRelateRecord>,
+    pub aabb: Vec<RawAabbRecord>,
+    pub trans: Vec<RawTransRecord>,
+    pub vec3: Vec<RawVec3Record>,
+    pub inst_relate_aabb: Vec<RawInstRelateAabbRecord>,
+    pub refno_assoc_index: Vec<RawRefnoAssocIndexRecord>,
+    pub row_counts: CanonicalRawRowCounts,
+}
+
+impl CanonicalRawBatch {
+    pub fn refresh_row_counts(&mut self) {
+        let mut counts = CanonicalRawRowCounts::default();
+        counts.set(CanonicalRawTable::RawInstInfo, self.inst_info.len());
+        counts.set(CanonicalRawTable::RawInstRelate, self.inst_relate.len());
+        counts.set(CanonicalRawTable::RawInstGeo, self.inst_geo.len());
+        counts.set(CanonicalRawTable::RawGeoRelate, self.geo_relate.len());
+        counts.set(CanonicalRawTable::RawTubiInfo, self.tubi_info.len());
+        counts.set(CanonicalRawTable::RawTubiRelate, self.tubi_relate.len());
+        counts.set(CanonicalRawTable::RawNegRelate, self.neg_relate.len());
+        counts.set(CanonicalRawTable::RawNgmrRelate, self.ngmr_relate.len());
+        counts.set(CanonicalRawTable::RawAabb, self.aabb.len());
+        counts.set(CanonicalRawTable::RawTrans, self.trans.len());
+        counts.set(CanonicalRawTable::RawVec3, self.vec3.len());
+        counts.set(
+            CanonicalRawTable::RawInstRelateAabb,
+            self.inst_relate_aabb.len(),
+        );
+        counts.set(
+            CanonicalRawTable::RawRefnoAssocIndex,
+            self.refno_assoc_index.len(),
+        );
+        self.row_counts = counts;
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CanonicalRawPlanner;
+
+impl CanonicalRawPlanner {
+    pub fn plan_shape_instances(&self, shape_insts: &ShapeInstancesData) -> CanonicalRawBatch {
+        let mut batch = CanonicalRawBatch::default();
+        let mut aabb_by_hash: HashMap<u64, String> = HashMap::new();
+        let mut trans_by_hash: HashMap<u64, String> = HashMap::new();
+        let mut vec3_by_hash: HashMap<u64, String> = HashMap::new();
+        let mut neg_geo_by_carrier: HashMap<String, Vec<u64>> = HashMap::new();
+        let mut ngmr_geo_by_key: HashMap<(String, String), Vec<u64>> = HashMap::new();
+
+        for (refno, info) in &shape_insts.inst_info_map {
+            let refno_s = refno.to_string();
+            let inst_id = info.id_str();
+            batch.inst_info.push(RawInstInfoRecord {
+                refno: refno_s.clone(),
+                inst_id: inst_id.clone(),
+                inst_relate_id: refno.to_inst_relate_key(),
+                payload: CanonicalRawPayload::surreal_json(info.gen_sur_json_full()),
+            });
+            batch.inst_relate.push(RawInstRelateRecord {
+                refno: refno_s,
+                pe_id: refno.to_pe_key(),
+                inst_id,
+                relation_id: refno.to_inst_relate_key(),
+            });
+
+            if let Some(aabb) = info.aabb {
+                let hash = gen_aabb_hash(&aabb);
+                aabb_by_hash
+                    .entry(hash)
+                    .or_insert_with(|| serde_json::to_string(&aabb).unwrap_or_default());
+                batch.inst_relate_aabb.push(RawInstRelateAabbRecord {
+                    refno: refno.to_string(),
+                    relation_id: refno.to_table_key("inst_relate_aabb"),
+                    aabb_id: hash,
+                });
+            }
+        }
+
+        for inst_geo_data in shape_insts.inst_geos_map.values() {
+            let inst_id = inst_geo_data.id();
+            let owner_refno = inst_geo_data.refno.to_string();
+            for inst in &inst_geo_data.insts {
+                if inst.geo_transform.translation.is_nan()
+                    || inst.geo_transform.rotation.is_nan()
+                    || inst.geo_transform.scale.is_nan()
+                {
+                    continue;
+                }
+
+                let trans_id = gen_plant_transform_hash(&inst.geo_transform);
+                trans_by_hash.entry(trans_id).or_insert_with(|| {
+                    serde_json::to_string(&inst.geo_transform).unwrap_or_default()
+                });
+
+                let mut pts_ids = Vec::new();
+                for key_pt in inst.geo_param.key_points() {
+                    let pts_hash = key_pt.gen_hash();
+                    pts_ids.push(pts_hash);
+                    vec3_by_hash
+                        .entry(pts_hash)
+                        .or_insert_with(|| serde_json::to_string(&key_pt).unwrap_or_default());
+                }
+
+                let cat_negs_str = if !inst.cata_neg_refnos.is_empty() {
+                    format!(
+                        ", cata_neg: [{}]",
+                        inst.cata_neg_refnos
+                            .iter()
+                            .map(|x| x.to_pe_key())
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    )
+                } else {
+                    String::new()
+                };
+                let pts_key_list = pts_ids
+                    .iter()
+                    .map(|hash| format!("vec3:⟨{}⟩", hash))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let relate_json = format!(
+                    r#"in: inst_info:⟨{0}⟩, out: inst_geo:⟨{1}⟩, trans: trans:⟨{2}⟩, geom_refno: pe:{3}, pts: [{4}], geo_type: '{5}', visible: {6} {7}"#,
+                    inst_id,
+                    inst.geo_hash,
+                    trans_id,
+                    inst.refno,
+                    pts_key_list,
+                    inst.geo_type,
+                    inst.visible,
+                    cat_negs_str
+                );
+                let relation_id = gen_string_hash(&relate_json);
+
+                batch.inst_geo.push(RawInstGeoRecord {
+                    owner_refno: owner_refno.clone(),
+                    inst_id: inst_id.clone(),
+                    geom_refno: inst.refno.to_string(),
+                    geo_hash: inst.geo_hash,
+                    payload: CanonicalRawPayload::surreal_json(inst.gen_unit_geo_sur_json()),
+                });
+                batch.geo_relate.push(RawGeoRelateRecord {
+                    relation_id,
+                    inst_id: inst_id.clone(),
+                    geo_hash: inst.geo_hash,
+                    geom_refno: inst.refno.to_string(),
+                    geo_type: inst.geo_type.to_string(),
+                    trans_id,
+                    visible: inst.visible,
+                    pts_ids,
+                });
+
+                match inst.geo_type {
+                    GeoBasicType::Neg => {
+                        neg_geo_by_carrier
+                            .entry(inst_geo_data.refno.to_string())
+                            .or_default()
+                            .push(relation_id);
+                    }
+                    GeoBasicType::CataCrossNeg => {
+                        ngmr_geo_by_key
+                            .entry((inst_geo_data.refno.to_string(), inst.refno.to_string()))
+                            .or_default()
+                            .push(relation_id);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        for (target, carriers) in &shape_insts.neg_relate_map {
+            for carrier in carriers {
+                let carrier_key = carrier.to_string();
+                let geo_relate_ids = neg_geo_by_carrier
+                    .get(&carrier_key)
+                    .cloned()
+                    .unwrap_or_default();
+                batch.neg_relate.push(RawDependencyRelateRecord {
+                    carrier_refno: carrier_key,
+                    target_refno: target.to_string(),
+                    geom_refno: None,
+                    relation_kind: "neg_relate".to_owned(),
+                    pending: geo_relate_ids.is_empty(),
+                    geo_relate_ids,
+                    payload: CanonicalRawPayload::placeholder(
+                        "Surreal neg_relate rows require geo_relate ids that may be loaded from DB across batches.",
+                    ),
+                });
+            }
+        }
+
+        for (target, ngmrs) in &shape_insts.ngmr_neg_relate_map {
+            for (carrier, geom_refno) in ngmrs {
+                let key = (carrier.to_string(), geom_refno.to_string());
+                let geo_relate_ids = ngmr_geo_by_key.get(&key).cloned().unwrap_or_default();
+                batch.ngmr_relate.push(RawDependencyRelateRecord {
+                    carrier_refno: carrier.to_string(),
+                    target_refno: target.to_string(),
+                    geom_refno: Some(geom_refno.to_string()),
+                    relation_kind: "ngmr_relate".to_owned(),
+                    pending: geo_relate_ids.is_empty(),
+                    geo_relate_ids,
+                    payload: CanonicalRawPayload::placeholder(
+                        "Surreal ngmr_relate rows require matching CataCrossNeg geo_relate ids in the same or prior batch.",
+                    ),
+                });
+            }
+        }
+
+        for (refno, tubi) in &shape_insts.inst_tubi_map {
+            let aabb_id = tubi.aabb.map(|aabb| {
+                let hash = gen_aabb_hash(&aabb);
+                aabb_by_hash
+                    .entry(hash)
+                    .or_insert_with(|| serde_json::to_string(&aabb).unwrap_or_default());
+                hash
+            });
+            batch.tubi_relate.push(RawTubiRelateRecord {
+                refno: refno.to_string(),
+                branch_id: tubi.refno.to_pe_key(),
+                aabb_id,
+                payload: CanonicalRawPayload::placeholder(
+                    "ShapeInstancesData carries tubing instance rows, but not the global tubi_info collector payload.",
+                ),
+            });
+        }
+
+        batch.aabb = aabb_by_hash
+            .into_iter()
+            .map(|(aabb_id, payload)| RawAabbRecord {
+                aabb_id,
+                payload: CanonicalRawPayload::surreal_json(payload),
+            })
+            .collect();
+        batch.trans = trans_by_hash
+            .into_iter()
+            .map(|(trans_id, payload)| RawTransRecord {
+                trans_id,
+                payload: CanonicalRawPayload::surreal_json(payload),
+            })
+            .collect();
+        batch.vec3 = vec3_by_hash
+            .into_iter()
+            .map(|(vec3_id, payload)| RawVec3Record {
+                vec3_id,
+                payload: CanonicalRawPayload::surreal_json(payload),
+            })
+            .collect();
+
+        for refno in shape_insts.inst_info_map.keys() {
+            let refno_s = refno.to_string();
+            let mut associated_records = Vec::new();
+            associated_records.push(refno.to_inst_relate_key());
+            if shape_insts
+                .inst_geos_map
+                .values()
+                .any(|geos| geos.refno == *refno)
+            {
+                associated_records.push(refno.to_pe_key());
+            }
+            if shape_insts.inst_tubi_map.contains_key(refno) {
+                associated_records.push(format!("tubi:{}", refno.to_pe_key()));
+            }
+            batch.refno_assoc_index.push(RawRefnoAssocIndexRecord {
+                refno: refno_s,
+                associated_records,
+                limitation: CanonicalRawTable::RawRefnoAssocIndex
+                    .phase1_limitation()
+                    .map(str::to_owned),
+            });
+        }
+        batch.refresh_row_counts();
+        batch
+    }
+}

--- a/src/fast_model/gen_model/canonical_records.rs
+++ b/src/fast_model/gen_model/canonical_records.rs
@@ -210,7 +210,17 @@ pub struct RawInstRelateAabbRecord {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RawRefnoAssocIndexRecord {
     pub refno: String,
-    pub associated_records: Vec<String>,
+    pub inst_relate_ids: Vec<String>,
+    pub inst_info_ids: Vec<String>,
+    pub geo_relate_ids: Vec<String>,
+    pub geo_hashes: Vec<String>,
+    pub neg_relate_ids: Vec<String>,
+    pub ngmr_relate_ids: Vec<String>,
+    pub inst_relate_aabb_ids: Vec<String>,
+    pub tubi_branch_keys: Vec<String>,
+    pub pending_phase2_inst_relate_bool_ids: Vec<String>,
+    pub pending_phase2_inst_relate_cata_bool_ids: Vec<String>,
+    pub unsupported_inst_relate_booled_aabb_ids: Vec<String>,
     pub limitation: Option<String>,
 }
 
@@ -267,8 +277,8 @@ impl CanonicalRawPlanner {
         let mut aabb_by_hash: HashMap<u64, String> = HashMap::new();
         let mut trans_by_hash: HashMap<u64, String> = HashMap::new();
         let mut vec3_by_hash: HashMap<u64, String> = HashMap::new();
-        let mut neg_geo_by_carrier: HashMap<String, Vec<u64>> = HashMap::new();
-        let mut ngmr_geo_by_key: HashMap<(String, String), Vec<u64>> = HashMap::new();
+        let mut neg_geo_by_carrier: HashMap<String, Vec<(u64, String)>> = HashMap::new();
+        let mut ngmr_geo_by_key: HashMap<(String, String), Vec<(u64, String)>> = HashMap::new();
 
         for (refno, info) in &shape_insts.inst_info_map {
             let refno_s = refno.to_string();
@@ -377,13 +387,13 @@ impl CanonicalRawPlanner {
                         neg_geo_by_carrier
                             .entry(inst_geo_data.refno.to_string())
                             .or_default()
-                            .push(relation_id);
+                            .push((relation_id, inst.refno.to_pe_key()));
                     }
                     GeoBasicType::CataCrossNeg => {
                         ngmr_geo_by_key
                             .entry((inst_geo_data.refno.to_string(), inst.refno.to_string()))
                             .or_default()
-                            .push(relation_id);
+                            .push((relation_id, inst.refno.to_pe_key()));
                     }
                     _ => {}
                 }
@@ -393,10 +403,14 @@ impl CanonicalRawPlanner {
         for (target, carriers) in &shape_insts.neg_relate_map {
             for carrier in carriers {
                 let carrier_key = carrier.to_string();
-                let geo_relate_ids = neg_geo_by_carrier
+                let matching_geo_relates = neg_geo_by_carrier
                     .get(&carrier_key)
                     .cloned()
                     .unwrap_or_default();
+                let geo_relate_ids = matching_geo_relates
+                    .iter()
+                    .map(|(relation_id, _)| *relation_id)
+                    .collect::<Vec<_>>();
                 batch.neg_relate.push(RawDependencyRelateRecord {
                     carrier_refno: carrier_key,
                     target_refno: target.to_string(),
@@ -414,7 +428,11 @@ impl CanonicalRawPlanner {
         for (target, ngmrs) in &shape_insts.ngmr_neg_relate_map {
             for (carrier, geom_refno) in ngmrs {
                 let key = (carrier.to_string(), geom_refno.to_string());
-                let geo_relate_ids = ngmr_geo_by_key.get(&key).cloned().unwrap_or_default();
+                let matching_geo_relates = ngmr_geo_by_key.get(&key).cloned().unwrap_or_default();
+                let geo_relate_ids = matching_geo_relates
+                    .iter()
+                    .map(|(relation_id, _)| *relation_id)
+                    .collect::<Vec<_>>();
                 batch.ngmr_relate.push(RawDependencyRelateRecord {
                     carrier_refno: carrier.to_string(),
                     target_refno: target.to_string(),
@@ -471,21 +489,92 @@ impl CanonicalRawPlanner {
 
         for refno in shape_insts.inst_info_map.keys() {
             let refno_s = refno.to_string();
-            let mut associated_records = Vec::new();
-            associated_records.push(refno.to_inst_relate_key());
-            if shape_insts
+            let inst_ids = shape_insts
                 .inst_geos_map
                 .values()
-                .any(|geos| geos.refno == *refno)
-            {
-                associated_records.push(refno.to_pe_key());
-            }
-            if shape_insts.inst_tubi_map.contains_key(refno) {
-                associated_records.push(format!("tubi:{}", refno.to_pe_key()));
-            }
+                .filter(|geos| geos.refno == *refno)
+                .map(|geos| geos.id())
+                .collect::<Vec<_>>();
+            let inst_info_ids = shape_insts
+                .inst_info_map
+                .get(refno)
+                .map(|info| vec![format!("inst_info:⟨{}⟩", info.id_str())])
+                .unwrap_or_default();
+            let geo_relate_ids = batch
+                .geo_relate
+                .iter()
+                .filter(|row| inst_ids.iter().any(|inst_id| inst_id == &row.inst_id))
+                .map(|row| format!("geo_relate:⟨{}⟩", row.relation_id))
+                .collect::<Vec<_>>();
+            let geo_hashes = shape_insts
+                .inst_geos_map
+                .values()
+                .filter(|geos| geos.refno == *refno)
+                .flat_map(|geos| geos.insts.iter().map(|inst| inst.geo_hash.to_string()))
+                .collect::<Vec<_>>();
+            let neg_relate_ids = neg_geo_by_carrier
+                .get(&refno_s)
+                .into_iter()
+                .flatten()
+                .flat_map(|(relation_id, _)| {
+                    shape_insts
+                        .neg_relate_map
+                        .iter()
+                        .filter(|(_, carriers)| carriers.iter().any(|carrier| carrier == refno))
+                        .map(move |(target, _)| {
+                            format!("neg_relate:['{}',{}]", relation_id, target.to_pe_key())
+                        })
+                })
+                .collect::<Vec<_>>();
+            let ngmr_relate_ids = ngmr_geo_by_key
+                .iter()
+                .filter(|((carrier, _), _)| carrier == &refno_s)
+                .flat_map(|((_, geom_refno), geo_relates)| {
+                    geo_relates.iter().flat_map(move |(relation_id, _)| {
+                        shape_insts
+                            .ngmr_neg_relate_map
+                            .iter()
+                            .filter_map(move |(target, ngmrs)| {
+                                ngmrs
+                                    .iter()
+                                    .any(|(carrier, geom)| {
+                                        carrier == refno && geom.to_string() == *geom_refno
+                                    })
+                                    .then(|| {
+                                        format!(
+                                            "ngmr_relate:['{}',{}]",
+                                            relation_id,
+                                            target.to_pe_key()
+                                        )
+                                    })
+                            })
+                    })
+                })
+                .collect::<Vec<_>>();
+            let inst_relate_aabb_ids = batch
+                .inst_relate_aabb
+                .iter()
+                .filter(|row| row.refno == refno_s)
+                .map(|row| row.relation_id.clone())
+                .collect::<Vec<_>>();
+            let tubi_branch_keys = shape_insts
+                .inst_tubi_map
+                .get(refno)
+                .map(|tubi| vec![tubi.refno.to_pe_key()])
+                .unwrap_or_default();
             batch.refno_assoc_index.push(RawRefnoAssocIndexRecord {
                 refno: refno_s,
-                associated_records,
+                inst_relate_ids: vec![refno.to_inst_relate_key()],
+                inst_info_ids,
+                geo_relate_ids,
+                geo_hashes,
+                neg_relate_ids,
+                ngmr_relate_ids,
+                inst_relate_aabb_ids,
+                tubi_branch_keys,
+                pending_phase2_inst_relate_bool_ids: vec![format!("inst_relate_bool:⟨{}⟩", refno)],
+                pending_phase2_inst_relate_cata_bool_ids: Vec::new(),
+                unsupported_inst_relate_booled_aabb_ids: Vec::new(),
                 limitation: CanonicalRawTable::RawRefnoAssocIndex
                     .phase1_limitation()
                     .map(str::to_owned),

--- a/src/fast_model/gen_model/mod.rs
+++ b/src/fast_model/gen_model/mod.rs
@@ -18,6 +18,7 @@ macro_rules! e3d_dbg {
 
 // 核心模块
 pub mod cache_miss_report; // IndexTree cache-first 缺失报告（output/<project>/cache_miss_report.json）
+pub mod canonical_records; // Phase 1 canonical raw writer boundary
 pub mod categorized_refnos;
 pub mod config; // 配置管理 (Phase 2)
 pub mod context; // 处理上下文

--- a/src/fast_model/gen_model/model_writer.rs
+++ b/src/fast_model/gen_model/model_writer.rs
@@ -1,16 +1,509 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use aios_core::RefnoEnum;
+use aios_core::error::init_save_database_error;
 use aios_core::geometry::ShapeInstancesData;
+use aios_core::{RefnoEnum, model_primary_db};
+use anyhow::Context;
+use async_trait::async_trait;
 use dashmap::DashMap;
 use parry3d::bounding_volume::Aabb;
 
-use crate::fast_model::pdms_inst::save_instance_data_with_report;
-use crate::options::ModelWriterMode;
+use super::boolean_task::BooleanTask;
+use super::manifold_bool::{BoolWorkerReport, run_bool_worker_from_tasks};
+use super::mesh_generate::{MeshResult, run_boolean_worker};
+use super::mesh_state::{flush_aabb_cache, use_file_mesh_state};
+use super::pdms_inst::{self, SaveInstanceDataReport};
+use super::pdms_inst_surreal;
+use crate::options::{BooleanPipelineMode, DbOptionExt, ModelWriterMode};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
+pub struct ModelWriterContext {
+    pub project_name: String,
+    pub use_surrealdb: bool,
+    pub defer_db_write: bool,
+    pub mode: ModelWriterMode,
+}
+
+impl ModelWriterContext {
+    pub fn from_db_option(db_option: &DbOptionExt) -> Self {
+        Self {
+            project_name: db_option.inner.project_name.clone(),
+            use_surrealdb: db_option.use_surrealdb,
+            defer_db_write: db_option.defer_db_write,
+            mode: db_option.model_writer_mode,
+        }
+    }
+}
+
+pub struct BaseInstanceBatch<'a> {
+    pub batch_id: u64,
+    pub shape_insts: &'a ShapeInstancesData,
+    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
+    pub replace_exist: bool,
+    pub write_inst_relate_aabb: bool,
+}
+
+pub struct MeshResultBatch<'a> {
+    pub batch_id: u64,
+    pub mesh_results: &'a HashMap<u64, MeshResult>,
+    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
+    pub mesh_pts_map: &'a DashMap<u64, String>,
+}
+
+pub struct InstRelateAabbBatch<'a> {
+    pub batch_id: u64,
+    pub shape_insts: &'a ShapeInstancesData,
+    pub mesh_results: &'a HashMap<u64, MeshResult>,
+    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
+}
+
+pub struct CleanupRequest<'a> {
+    pub seed_refnos: &'a [RefnoEnum],
+}
+
+pub struct ReconcileRequest<'a> {
+    pub all_refnos: &'a [RefnoEnum],
+    pub candidate_carriers: &'a [RefnoEnum],
+}
+
+pub struct BooleanBridgeRequest {
+    pub mode: BooleanPipelineMode,
+    pub db_option: Arc<aios_core::options::DbOption>,
+    pub bool_tasks: Vec<BooleanTask>,
+    pub use_surrealdb: bool,
+    pub defer_db_write: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct BooleanBridgeReport {
+    pub pipeline: &'static str,
+    pub total: usize,
+    pub cata_cnt: usize,
+    pub inst_cnt: usize,
+    pub success: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub deferred_mode: bool,
+}
+
+impl BooleanBridgeReport {
+    fn db_legacy_executed() -> Self {
+        Self {
+            pipeline: "db_legacy",
+            total: 0,
+            cata_cnt: 0,
+            inst_cnt: 0,
+            success: 0,
+            failed: 0,
+            skipped: 0,
+            deferred_mode: false,
+        }
+    }
+
+    fn skipped(pipeline: &'static str, total: usize, reason: &str) -> Self {
+        println!(
+            "[model-writer:surreal] stage=boolean_bridge skipped pipeline={} reason={} total={}",
+            pipeline, reason, total
+        );
+        Self {
+            pipeline,
+            total,
+            cata_cnt: 0,
+            inst_cnt: 0,
+            success: 0,
+            failed: 0,
+            skipped: total,
+            deferred_mode: false,
+        }
+    }
+}
+
+impl From<BoolWorkerReport> for BooleanBridgeReport {
+    fn from(report: BoolWorkerReport) -> Self {
+        Self {
+            pipeline: "memory_tasks",
+            total: report.total,
+            cata_cnt: report.cata_cnt,
+            inst_cnt: report.inst_cnt,
+            success: report.success,
+            failed: report.failed,
+            skipped: report.skipped,
+            deferred_mode: report.deferred_mode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FinalizeRequest {
+    pub total_batches: u64,
+    pub completed_batches: usize,
+    pub mesh_cache_hits: usize,
+    pub mesh_new_generated: usize,
+    pub missing_neg_candidates: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct FinalizeSummary {
+    pub backend: &'static str,
+    pub total_batches: u64,
+    pub completed_batches: usize,
+}
+
+#[async_trait]
+pub trait ModelWriteBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    async fn init(&self, context: &ModelWriterContext) -> anyhow::Result<()>;
+
+    async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()>;
+
+    async fn write_base_batch(
+        &self,
+        batch: BaseInstanceBatch<'_>,
+    ) -> anyhow::Result<SaveInstanceDataReport>;
+
+    async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()>;
+
+    async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()>;
+
+    async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize>;
+
+    async fn run_boolean_bridge(
+        &self,
+        request: BooleanBridgeRequest,
+    ) -> anyhow::Result<BooleanBridgeReport>;
+
+    async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary>;
+}
+
+pub fn create_model_writer(db_option: &DbOptionExt) -> anyhow::Result<Arc<dyn ModelWriteBackend>> {
+    match db_option.model_writer_mode {
+        ModelWriterMode::Surreal => {
+            println!("[model-writer] factory selected primary=surreal mirror=none fail_fast=true");
+            Ok(Arc::new(SurrealModelWriteBackend))
+        }
+        ModelWriterMode::DrainOnly => {
+            anyhow::bail!(
+                "drain-only is an explicit non-persistent sink and does not create a persistence backend"
+            )
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SurrealModelWriteBackend;
+
+#[async_trait]
+impl ModelWriteBackend for SurrealModelWriteBackend {
+    fn name(&self) -> &'static str {
+        "surreal"
+    }
+
+    async fn init(&self, context: &ModelWriterContext) -> anyhow::Result<()> {
+        println!(
+            "[model-writer:surreal] stage=init project={} use_surrealdb={} defer_db_write={} mode={}",
+            context.project_name,
+            context.use_surrealdb,
+            context.defer_db_write,
+            context.mode.as_str()
+        );
+        anyhow::ensure!(
+            context.use_surrealdb,
+            "Surreal model writer requires use_surrealdb=true for the current input/write contract"
+        );
+        aios_core::rs_surreal::inst::init_model_tables()
+            .await
+            .context("model_writer surreal init_model_tables failed")?;
+        Ok(())
+    }
+
+    async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()> {
+        println!(
+            "[model-writer:surreal] stage=cleanup seed_refnos={}",
+            request.seed_refnos.len()
+        );
+        pdms_inst::pre_cleanup_for_regen(request.seed_refnos)
+            .await
+            .context("model_writer surreal legacy cleanup failed")?;
+        pdms_inst_surreal::pre_cleanup_for_regen_surreal(request.seed_refnos)
+            .await
+            .context("model_writer surreal relation cleanup failed")?;
+        println!(
+            "[model-writer:surreal] stage=cleanup done seed_refnos={}",
+            request.seed_refnos.len()
+        );
+        Ok(())
+    }
+
+    async fn write_base_batch(
+        &self,
+        batch: BaseInstanceBatch<'_>,
+    ) -> anyhow::Result<SaveInstanceDataReport> {
+        println!(
+            "[model-writer:surreal] stage=base batch={} inst_info={} inst_tubi={} geo_keys={}",
+            batch.batch_id,
+            batch.shape_insts.inst_info_map.len(),
+            batch.shape_insts.inst_tubi_map.len(),
+            batch.shape_insts.inst_geos_map.len()
+        );
+        let mesh_results: HashMap<u64, MeshResult> = HashMap::new();
+        let report = pdms_inst::save_instance_data_with_report(
+            batch.shape_insts,
+            batch.replace_exist,
+            &mesh_results,
+            batch.mesh_aabb_map,
+            batch.write_inst_relate_aabb,
+        )
+        .await
+        .with_context(|| format!("model_writer surreal base batch {} failed", batch.batch_id))?;
+        println!(
+            "[model-writer:surreal] stage=base batch={} done missing_neg_candidates={}",
+            batch.batch_id,
+            report.missing_neg_carriers.len()
+        );
+        Ok(report)
+    }
+
+    async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()> {
+        if use_file_mesh_state() {
+            flush_aabb_cache();
+            println!(
+                "[model-writer:surreal] stage=mesh_results batch={} file_mesh_state=true flushed_aabb_cache=true",
+                batch.batch_id
+            );
+            return Ok(());
+        }
+
+        if batch.mesh_results.is_empty() {
+            println!(
+                "[model-writer:surreal] stage=mesh_results batch={} mesh_results=0",
+                batch.batch_id
+            );
+            return Ok(());
+        }
+
+        let pts_written = save_pts_to_surreal_strict(batch.mesh_pts_map)
+            .await
+            .with_context(|| {
+                format!(
+                    "model_writer surreal mesh pts batch {} failed",
+                    batch.batch_id
+                )
+            })?;
+        let aabb_written = save_aabb_to_surreal_strict(batch.mesh_aabb_map)
+            .await
+            .with_context(|| {
+                format!(
+                    "model_writer surreal mesh aabb batch {} failed",
+                    batch.batch_id
+                )
+            })?;
+
+        let mut update_sql = String::new();
+        for (geo_hash, mesh_result) in batch.mesh_results {
+            update_sql.push_str(&mesh_result.to_update_sql(&geo_hash.to_string()));
+        }
+
+        if !update_sql.is_empty() {
+            model_primary_db().query(&update_sql).await.map_err(|e| {
+                let preview: String = update_sql.chars().take(500).collect();
+                anyhow::anyhow!(
+                    "model_writer surreal mesh result batch {} failed: error={}, sql_preview={}",
+                    batch.batch_id,
+                    e,
+                    preview
+                )
+            })?;
+        }
+
+        println!(
+            "[model-writer:surreal] stage=mesh_results batch={} mesh_results={} pts_rows={} aabb_rows={} update_sql_len={}",
+            batch.batch_id,
+            batch.mesh_results.len(),
+            pts_written,
+            aabb_written,
+            update_sql.len()
+        );
+        Ok(())
+    }
+
+    async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()> {
+        let (aabb_rows_map, inst_relate_aabb_rows, inst_relate_aabb_ids) =
+            pdms_inst::build_inst_relate_aabb_rows(
+                batch.shape_insts,
+                batch.mesh_results,
+                batch.mesh_aabb_map,
+            )?;
+        let aabb_count = aabb_rows_map.len();
+        let rel_count = inst_relate_aabb_rows.len();
+        pdms_inst::save_inst_relate_aabb_rows(
+            &aabb_rows_map,
+            &inst_relate_aabb_rows,
+            &inst_relate_aabb_ids,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "model_writer surreal inst_relate_aabb batch {} failed",
+                batch.batch_id
+            )
+        })?;
+        println!(
+            "[model-writer:surreal] stage=inst_relate_aabb batch={} aabb_rows={} relation_rows={}",
+            batch.batch_id, aabb_count, rel_count
+        );
+        Ok(())
+    }
+
+    async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize> {
+        println!(
+            "[model-writer:surreal] stage=reconcile_missing_neg all_refnos={} candidate_carriers={}",
+            request.all_refnos.len(),
+            request.candidate_carriers.len()
+        );
+        let inserted =
+            pdms_inst::reconcile_missing_neg_relate(request.all_refnos, request.candidate_carriers)
+                .await
+                .context("model_writer surreal reconcile_missing_neg failed")?;
+        println!(
+            "[model-writer:surreal] stage=reconcile_missing_neg done inserted={}",
+            inserted
+        );
+        Ok(inserted)
+    }
+
+    async fn run_boolean_bridge(
+        &self,
+        request: BooleanBridgeRequest,
+    ) -> anyhow::Result<BooleanBridgeReport> {
+        match request.mode {
+            BooleanPipelineMode::DbLegacy => {
+                if request.use_surrealdb && !request.defer_db_write {
+                    println!("[model-writer:surreal] stage=boolean_bridge pipeline=db_legacy");
+                    run_boolean_worker(request.db_option, 100)
+                        .await
+                        .context("model_writer surreal db_legacy boolean bridge failed")?;
+                    Ok(BooleanBridgeReport::db_legacy_executed())
+                } else {
+                    Ok(BooleanBridgeReport::skipped(
+                        "db_legacy",
+                        0,
+                        "use_surrealdb/defer_db_write guard",
+                    ))
+                }
+            }
+            BooleanPipelineMode::MemoryTasks => {
+                if !request.use_surrealdb {
+                    return Ok(BooleanBridgeReport::skipped(
+                        "memory_tasks",
+                        request.bool_tasks.len(),
+                        "use_surrealdb=false",
+                    ));
+                }
+                println!(
+                    "[model-writer:surreal] stage=boolean_bridge pipeline=memory_tasks total_tasks={}",
+                    request.bool_tasks.len()
+                );
+                let report =
+                    run_bool_worker_from_tasks(request.bool_tasks, request.db_option, None)
+                        .await
+                        .context("model_writer surreal memory_tasks boolean bridge failed")?;
+                Ok(report.into())
+            }
+        }
+    }
+
+    async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary> {
+        println!(
+            "[model-writer:surreal] stage=finalize total_batches={} completed_batches={} mesh_cache_hits={} mesh_new_generated={} missing_neg_candidates={}",
+            request.total_batches,
+            request.completed_batches,
+            request.mesh_cache_hits,
+            request.mesh_new_generated,
+            request.missing_neg_candidates
+        );
+        Ok(FinalizeSummary {
+            backend: self.name(),
+            total_batches: request.total_batches,
+            completed_batches: request.completed_batches,
+        })
+    }
+}
+
+async fn save_aabb_to_surreal_strict(aabb_map: &DashMap<String, Aabb>) -> anyhow::Result<usize> {
+    if aabb_map.is_empty() {
+        return Ok(0);
+    }
+
+    let keys = aabb_map
+        .iter()
+        .map(|kv| kv.key().clone())
+        .collect::<Vec<_>>();
+    let mut written = 0usize;
+    for chunk in keys.chunks(300) {
+        let mut rows: Vec<String> = Vec::with_capacity(chunk.len());
+        for k in chunk {
+            let Some(v) = aabb_map.get(k) else {
+                continue;
+            };
+            let d = serde_json::to_string(v.value())?;
+            let id_key = if k.starts_with("aabb:") {
+                k.to_string()
+            } else {
+                format!("aabb:⟨{}⟩", k)
+            };
+            rows.push(format!("{{'id':{id_key}, 'd':{d}}}"));
+        }
+        if rows.is_empty() {
+            continue;
+        }
+        let sql = format!("INSERT IGNORE INTO aabb [{}];", rows.join(","));
+        if let Err(e) = model_primary_db().query(&sql).await {
+            init_save_database_error(
+                &format!("{sql}\n-- err: {e}"),
+                &std::panic::Location::caller().to_string(),
+            );
+            anyhow::bail!("写入 mesh aabb 失败: {e}");
+        }
+        written += rows.len();
+    }
+    Ok(written)
+}
+
+async fn save_pts_to_surreal_strict(vec3_map: &DashMap<u64, String>) -> anyhow::Result<usize> {
+    if vec3_map.is_empty() {
+        return Ok(0);
+    }
+
+    let keys = vec3_map.iter().map(|kv| *kv.key()).collect::<Vec<_>>();
+    let mut written = 0usize;
+    for chunk in keys.chunks(100) {
+        let mut rows: Vec<String> = Vec::with_capacity(chunk.len());
+        for &k in chunk {
+            let Some(v) = vec3_map.get(&k) else {
+                continue;
+            };
+            rows.push(format!("{{'id':vec3:⟨{}⟩, 'd':{}}}", k, v.value()));
+        }
+        if rows.is_empty() {
+            continue;
+        }
+        let sql = format!("INSERT IGNORE INTO vec3 [{}];", rows.join(","));
+        if let Err(e) = model_primary_db().query(&sql).await {
+            init_save_database_error(
+                &format!("{sql}\n-- err: {e}"),
+                &std::panic::Location::caller().to_string(),
+            );
+            anyhow::bail!("写入 mesh pts/vec3 失败: {e}");
+        }
+        written += rows.len();
+    }
+    Ok(written)
+}
+
+#[derive(Debug, Default)]
 pub struct DrainOnlyStats {
     pub batches: usize,
     pub instances: usize,
@@ -59,206 +552,26 @@ impl DrainOnlyStats {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct ModelWriteBatchReport {
-    pub missing_neg_carriers: Vec<RefnoEnum>,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct ModelWriterFinishReport {
-    pub writer_name: &'static str,
-    pub drain_only_stats: Option<DrainOnlyStats>,
-}
-
-#[async_trait::async_trait]
-pub trait ModelWriter: Send + Sync {
-    fn name(&self) -> &'static str;
-
-    fn writes_to_surreal(&self) -> bool;
-
-    fn runs_downstream_pipeline(&self) -> bool;
-
-    /// Called once before worker tasks start.
-    async fn prepare(&self) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    /// May be called concurrently by multiple base-writer workers.
-    async fn write_batch(
-        &self,
-        batch: &ShapeInstancesData,
-    ) -> anyhow::Result<ModelWriteBatchReport>;
-
-    /// Called once after all worker tasks finish.
-    async fn finish(&self) -> anyhow::Result<ModelWriterFinishReport> {
-        Ok(ModelWriterFinishReport {
-            writer_name: self.name(),
-            drain_only_stats: None,
-        })
-    }
-}
-
-pub struct SurrealModelWriter {
-    mesh_aabb_map: Arc<DashMap<String, Aabb>>,
-    missing_neg_carriers: Arc<Mutex<HashSet<RefnoEnum>>>,
-}
-
-impl SurrealModelWriter {
-    pub fn new(
-        mesh_aabb_map: Arc<DashMap<String, Aabb>>,
-        missing_neg_carriers: Arc<Mutex<HashSet<RefnoEnum>>>,
-    ) -> Self {
-        Self {
-            mesh_aabb_map,
-            missing_neg_carriers,
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl ModelWriter for SurrealModelWriter {
-    fn name(&self) -> &'static str {
-        "surreal"
-    }
-
-    fn writes_to_surreal(&self) -> bool {
-        true
-    }
-
-    fn runs_downstream_pipeline(&self) -> bool {
-        true
-    }
-
-    async fn write_batch(
-        &self,
-        batch: &ShapeInstancesData,
-    ) -> anyhow::Result<ModelWriteBatchReport> {
-        let save_report = save_instance_data_with_report(
-            batch,
-            false,
-            &HashMap::new(),
-            &self.mesh_aabb_map,
-            false,
-        )
-        .await?;
-        if !save_report.missing_neg_carriers.is_empty() {
-            let mut guard = self
-                .missing_neg_carriers
-                .lock()
-                .map_err(|_| anyhow::anyhow!("missing_neg_carriers mutex poisoned"))?;
-            guard.extend(save_report.missing_neg_carriers.iter().copied());
-        }
-        Ok(ModelWriteBatchReport {
-            missing_neg_carriers: save_report.missing_neg_carriers,
-        })
-    }
-}
-
-pub struct DrainOnlyWriter {
-    started: Instant,
-    stats: Mutex<DrainOnlyStats>,
-}
-
-impl DrainOnlyWriter {
-    pub fn new() -> Self {
-        Self {
-            started: Instant::now(),
-            stats: Mutex::new(DrainOnlyStats::default()),
-        }
-    }
-}
-
-impl Default for DrainOnlyWriter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[async_trait::async_trait]
-impl ModelWriter for DrainOnlyWriter {
-    fn name(&self) -> &'static str {
-        "drain-only"
-    }
-
-    fn writes_to_surreal(&self) -> bool {
-        false
-    }
-
-    fn runs_downstream_pipeline(&self) -> bool {
-        false
-    }
-
-    async fn write_batch(
-        &self,
-        batch: &ShapeInstancesData,
-    ) -> anyhow::Result<ModelWriteBatchReport> {
-        let progress = {
-            let mut stats = self
-                .stats
-                .lock()
-                .map_err(|_| anyhow::anyhow!("drain-only stats mutex poisoned"))?;
-            stats.add_batch(batch);
-            if stats.batches % 100 == 0 {
-                Some((stats.batches, stats.instances, stats.geo_instances))
-            } else {
-                None
-            }
-        };
-
-        if let Some((batches, instances, geo_instances)) = progress {
-            println!(
-                "[model-writer:drain-only] drained batches={} instances={} geo_instances={} elapsed_ms={}",
-                batches,
-                instances,
-                geo_instances,
-                self.started.elapsed().as_millis()
-            );
-        }
-
-        Ok(ModelWriteBatchReport::default())
-    }
-
-    async fn finish(&self) -> anyhow::Result<ModelWriterFinishReport> {
-        let mut stats = self
-            .stats
-            .lock()
-            .map_err(|_| anyhow::anyhow!("drain-only stats mutex poisoned"))?
-            .clone();
-        stats.elapsed = self.started.elapsed();
-        Ok(ModelWriterFinishReport {
-            writer_name: self.name(),
-            drain_only_stats: Some(stats),
-        })
-    }
-}
-
-pub fn create_model_writer(
-    mode: ModelWriterMode,
-    mesh_aabb_map: Arc<DashMap<String, Aabb>>,
-    missing_neg_carriers: Arc<Mutex<HashSet<RefnoEnum>>>,
-) -> Arc<dyn ModelWriter> {
-    match mode {
-        ModelWriterMode::Surreal => {
-            Arc::new(SurrealModelWriter::new(mesh_aabb_map, missing_neg_carriers))
-        }
-        ModelWriterMode::DrainOnly => Arc::new(DrainOnlyWriter::new()),
-    }
-}
-
-pub async fn run_model_writer_sink(
-    receiver: flume::Receiver<ShapeInstancesData>,
-    writer: Arc<dyn ModelWriter>,
-) -> anyhow::Result<ModelWriterFinishReport> {
-    writer.prepare().await?;
-    while let Ok(batch) = receiver.recv_async().await {
-        writer.write_batch(&batch).await?;
-    }
-    writer.finish().await
-}
-
 pub async fn run_drain_only_sink(
     receiver: flume::Receiver<ShapeInstancesData>,
 ) -> anyhow::Result<DrainOnlyStats> {
-    let report = run_model_writer_sink(receiver, Arc::new(DrainOnlyWriter::new())).await?;
-    Ok(report.drain_only_stats.unwrap_or_default())
+    let started = Instant::now();
+    let mut stats = DrainOnlyStats::default();
+
+    while let Ok(batch) = receiver.recv_async().await {
+        stats.add_batch(&batch);
+
+        if stats.batches % 100 == 0 {
+            println!(
+                "[model-writer:drain-only] drained batches={} instances={} geo_instances={} elapsed_ms={}",
+                stats.batches,
+                stats.instances,
+                stats.geo_instances,
+                started.elapsed().as_millis()
+            );
+        }
+    }
+
+    stats.elapsed = started.elapsed();
+    Ok(stats)
 }

--- a/src/fast_model/gen_model/model_writer/drain_only.rs
+++ b/src/fast_model/gen_model/model_writer/drain_only.rs
@@ -1,3 +1,18 @@
+//! DrainOnly backend = baseline mode.
+//!
+//! Architecture invariant: when `ModelWriterMode::DrainOnly` is selected, the
+//! orchestrator takes the fast path (`run_drain_only_sink`) and only routes
+//! `init` + `finalize` through this trait impl. The middle six methods —
+//! `cleanup` / `write_base_batch` / `persist_mesh_results` /
+//! `write_inst_relate_aabb` / `reconcile_missing_neg` / `run_boolean_bridge` —
+//! exist as defensive scaffolding for the mock/verify binary and any future
+//! callsite that wants to drive the trait directly. They are intentionally
+//! **not** consumed by the production pipeline so that DrainOnly stays a clean
+//! "skip all persistence" baseline for measuring write-backend timing across
+//! Surreal / Parquet / DuckLake. Do not refactor the orchestrator to route
+//! these six methods without re-validating that the baseline IO-skip semantic
+//! is preserved (see `orchestrator.rs` `DrainOnly` fast-path comment).
+
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -123,6 +138,8 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
     }
 
     async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()> {
+        // architectural-invariant: not called by orchestrator main pipeline
+        // when ModelWriterMode::DrainOnly is selected (baseline fast path).
         // Drain-only 是非持久化压测 sink，禁止删除任何现有数据；此处仅记录意图。
         println!(
             "[model-writer:drain-only] stage=cleanup noop seed_refnos={}",
@@ -135,6 +152,8 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
         &self,
         batch: BaseInstanceBatch<'_>,
     ) -> anyhow::Result<WriteBaseReport> {
+        // architectural-invariant: not called by orchestrator main pipeline
+        // when ModelWriterMode::DrainOnly is selected (baseline fast path).
         {
             let mut stats = self.stats.lock().expect("drain-only stats lock");
             stats.add_batch(batch.shape_insts);
@@ -154,6 +173,8 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
     }
 
     async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()> {
+        // architectural-invariant: not called by orchestrator main pipeline
+        // when ModelWriterMode::DrainOnly is selected (baseline fast path).
         let count = batch.mesh_results.len();
         {
             let mut stats = self.stats.lock().expect("drain-only stats lock");
@@ -168,6 +189,8 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
     }
 
     async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()> {
+        // architectural-invariant: not called by orchestrator main pipeline
+        // when ModelWriterMode::DrainOnly is selected (baseline fast path).
         {
             let mut stats = self.stats.lock().expect("drain-only stats lock");
             stats.inst_relate_aabb_batches += 1;
@@ -182,6 +205,8 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
     }
 
     async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize> {
+        // architectural-invariant: not called by orchestrator main pipeline
+        // when ModelWriterMode::DrainOnly is selected (baseline fast path).
         println!(
             "[model-writer:drain-only] stage=reconcile_missing_neg noop all_refnos={} candidate_carriers={}",
             request.all_refnos.len(),
@@ -194,6 +219,8 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
         &self,
         request: BooleanBridgeRequest,
     ) -> anyhow::Result<BooleanBridgeReport> {
+        // architectural-invariant: not called by orchestrator main pipeline
+        // when ModelWriterMode::DrainOnly is selected (baseline fast path).
         println!(
             "[model-writer:drain-only] stage=boolean_bridge noop mode={:?} bool_tasks={}",
             request.mode,

--- a/src/fast_model/gen_model/model_writer/drain_only.rs
+++ b/src/fast_model/gen_model/model_writer/drain_only.rs
@@ -1,0 +1,235 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use aios_core::geometry::ShapeInstancesData;
+use async_trait::async_trait;
+
+use super::{
+    BaseInstanceBatch, BooleanBridgeReport, BooleanBridgeRequest, CleanupRequest, FinalizeRequest,
+    FinalizeSummary, InstRelateAabbBatch, MeshResultBatch, ModelWriterBackend, ModelWriterContext,
+    ReconcileRequest, WriteBaseReport,
+};
+
+#[derive(Debug, Default)]
+pub struct DrainOnlyStats {
+    pub batches: usize,
+    pub instances: usize,
+    pub inst_info: usize,
+    pub inst_tubi: usize,
+    pub geo_keys: usize,
+    pub geo_instances: usize,
+    pub neg_relations: usize,
+    pub ngmr_relations: usize,
+    pub mesh_result_batches: usize,
+    pub mesh_results: usize,
+    pub inst_relate_aabb_batches: usize,
+    pub elapsed: Duration,
+}
+
+impl DrainOnlyStats {
+    pub(crate) fn add_batch(&mut self, batch: &ShapeInstancesData) {
+        self.batches += 1;
+        self.instances += batch.inst_cnt();
+        self.inst_info += batch.inst_info_map.len();
+        self.inst_tubi += batch.inst_tubi_map.len();
+        self.geo_keys += batch.inst_geos_map.len();
+        self.geo_instances += batch
+            .inst_geos_map
+            .values()
+            .map(|geos| geos.insts.len())
+            .sum::<usize>();
+        self.neg_relations += batch.neg_relate_map.values().map(Vec::len).sum::<usize>();
+        self.ngmr_relations += batch
+            .ngmr_neg_relate_map
+            .values()
+            .map(Vec::len)
+            .sum::<usize>();
+    }
+
+    pub fn print_summary(&self) {
+        println!(
+            "[model-writer:drain-only] summary: batches={} instances={} inst_info={} inst_tubi={} geo_keys={} geo_instances={} neg_relations={} ngmr_relations={} mesh_batches={} mesh_results={} inst_relate_aabb_batches={} elapsed_ms={}",
+            self.batches,
+            self.instances,
+            self.inst_info,
+            self.inst_tubi,
+            self.geo_keys,
+            self.geo_instances,
+            self.neg_relations,
+            self.ngmr_relations,
+            self.mesh_result_batches,
+            self.mesh_results,
+            self.inst_relate_aabb_batches,
+            self.elapsed.as_millis()
+        );
+    }
+}
+
+pub async fn run_drain_only_sink(
+    receiver: flume::Receiver<ShapeInstancesData>,
+) -> anyhow::Result<DrainOnlyStats> {
+    let started = Instant::now();
+    let mut stats = DrainOnlyStats::default();
+
+    while let Ok(batch) = receiver.recv_async().await {
+        stats.add_batch(&batch);
+
+        if stats.batches % 100 == 0 {
+            println!(
+                "[model-writer:drain-only] drained batches={} instances={} geo_instances={} elapsed_ms={}",
+                stats.batches,
+                stats.instances,
+                stats.geo_instances,
+                started.elapsed().as_millis()
+            );
+        }
+    }
+
+    stats.elapsed = started.elapsed();
+    Ok(stats)
+}
+
+#[derive(Debug)]
+pub struct DrainOnlyModelWriterBackend {
+    stats: Mutex<DrainOnlyStats>,
+    started: Mutex<Option<Instant>>,
+}
+
+impl Default for DrainOnlyModelWriterBackend {
+    fn default() -> Self {
+        Self {
+            stats: Mutex::new(DrainOnlyStats::default()),
+            started: Mutex::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl ModelWriterBackend for DrainOnlyModelWriterBackend {
+    fn name(&self) -> &'static str {
+        "drain-only"
+    }
+
+    async fn init(&self, context: &ModelWriterContext) -> anyhow::Result<()> {
+        println!(
+            "[model-writer:drain-only] stage=init project={} use_surrealdb={} defer_db_write={} mode={}",
+            context.project_name,
+            context.use_surrealdb,
+            context.defer_db_write,
+            context.mode.as_str()
+        );
+        *self.started.lock().expect("drain-only started lock") = Some(Instant::now());
+        Ok(())
+    }
+
+    async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()> {
+        // Drain-only 是非持久化压测 sink，禁止删除任何现有数据；此处仅记录意图。
+        println!(
+            "[model-writer:drain-only] stage=cleanup noop seed_refnos={}",
+            request.seed_refnos.len()
+        );
+        Ok(())
+    }
+
+    async fn write_base_batch(
+        &self,
+        batch: BaseInstanceBatch<'_>,
+    ) -> anyhow::Result<WriteBaseReport> {
+        {
+            let mut stats = self.stats.lock().expect("drain-only stats lock");
+            stats.add_batch(batch.shape_insts);
+        }
+        println!(
+            "[model-writer:drain-only] stage=base batch={} inst_info={} inst_tubi={} geo_keys={}",
+            batch.batch_id,
+            batch.shape_insts.inst_info_map.len(),
+            batch.shape_insts.inst_tubi_map.len(),
+            batch.shape_insts.inst_geos_map.len()
+        );
+        Ok(WriteBaseReport {
+            batch_id: batch.batch_id,
+            missing_neg_count: 0,
+            missing_neg_carriers: Vec::new(),
+        })
+    }
+
+    async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()> {
+        let count = batch.mesh_results.len();
+        {
+            let mut stats = self.stats.lock().expect("drain-only stats lock");
+            stats.mesh_result_batches += 1;
+            stats.mesh_results += count;
+        }
+        println!(
+            "[model-writer:drain-only] stage=mesh_results batch={} mesh_results={}",
+            batch.batch_id, count
+        );
+        Ok(())
+    }
+
+    async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()> {
+        {
+            let mut stats = self.stats.lock().expect("drain-only stats lock");
+            stats.inst_relate_aabb_batches += 1;
+        }
+        println!(
+            "[model-writer:drain-only] stage=inst_relate_aabb batch={} mesh_results={} aabb_keys={}",
+            batch.batch_id,
+            batch.mesh_results.len(),
+            batch.mesh_aabb_map.len()
+        );
+        Ok(())
+    }
+
+    async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize> {
+        println!(
+            "[model-writer:drain-only] stage=reconcile_missing_neg noop all_refnos={} candidate_carriers={}",
+            request.all_refnos.len(),
+            request.candidate_carriers.len()
+        );
+        Ok(0)
+    }
+
+    async fn run_boolean_bridge(
+        &self,
+        request: BooleanBridgeRequest,
+    ) -> anyhow::Result<BooleanBridgeReport> {
+        println!(
+            "[model-writer:drain-only] stage=boolean_bridge noop mode={:?} bool_tasks={}",
+            request.mode,
+            request.bool_tasks.len()
+        );
+        Ok(BooleanBridgeReport::skipped(
+            "drain_only",
+            request.bool_tasks.len(),
+            "drain-only is non-persistent",
+        ))
+    }
+
+    async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary> {
+        let elapsed = self
+            .started
+            .lock()
+            .expect("drain-only started lock")
+            .map(|t| t.elapsed())
+            .unwrap_or_default();
+        {
+            let mut stats = self.stats.lock().expect("drain-only stats lock");
+            stats.elapsed = elapsed;
+            stats.print_summary();
+        }
+        println!(
+            "[model-writer:drain-only] stage=finalize total_batches={} completed_batches={} mesh_cache_hits={} mesh_new_generated={} missing_neg_candidates={}",
+            request.total_batches,
+            request.completed_batches,
+            request.mesh_cache_hits,
+            request.mesh_new_generated,
+            request.missing_neg_candidates
+        );
+        Ok(FinalizeSummary {
+            backend: self.name(),
+            total_batches: request.total_batches,
+            completed_batches: request.completed_batches,
+        })
+    }
+}

--- a/src/fast_model/gen_model/model_writer/mock.rs
+++ b/src/fast_model/gen_model/model_writer/mock.rs
@@ -1,0 +1,147 @@
+#![cfg(feature = "model-writer-mock")]
+
+use std::sync::Mutex;
+
+use aios_core::RefnoEnum;
+use async_trait::async_trait;
+
+use super::{
+    BaseInstanceBatch, BooleanBridgeReport, BooleanBridgeRequest, CleanupRequest, FinalizeRequest,
+    FinalizeSummary, InstRelateAabbBatch, MeshResultBatch, ModelWriterBackend, ModelWriterContext,
+    ReconcileRequest, WriteBaseReport,
+};
+
+/// 记录每次 trait 方法调用的 fixture backend，仅用于契约验证。
+///
+/// **不要**用于 release 构建：本类型仅在 feature `model-writer-mock` 下编译。
+#[derive(Debug, Default)]
+pub struct RecordingBackend {
+    calls: Mutex<Vec<String>>,
+    pub injected_reconcile_inserted: Mutex<usize>,
+    pub injected_missing_neg: Mutex<Vec<RefnoEnum>>,
+}
+
+impl RecordingBackend {
+    pub fn snapshot(&self) -> Vec<String> {
+        self.calls.lock().expect("recording lock").clone()
+    }
+
+    fn record(&self, line: impl Into<String>) {
+        self.calls.lock().expect("recording lock").push(line.into());
+    }
+}
+
+#[async_trait]
+impl ModelWriterBackend for RecordingBackend {
+    fn name(&self) -> &'static str {
+        "mock"
+    }
+
+    async fn init(&self, context: &ModelWriterContext) -> anyhow::Result<()> {
+        self.record(format!(
+            "init:project={},use_surrealdb={},defer_db_write={},mode={}",
+            context.project_name,
+            context.use_surrealdb,
+            context.defer_db_write,
+            context.mode.as_str()
+        ));
+        Ok(())
+    }
+
+    async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()> {
+        self.record(format!(
+            "cleanup:seed_refnos={}",
+            request.seed_refnos.len()
+        ));
+        Ok(())
+    }
+
+    async fn write_base_batch(
+        &self,
+        batch: BaseInstanceBatch<'_>,
+    ) -> anyhow::Result<WriteBaseReport> {
+        self.record(format!(
+            "write_base_batch:batch={},inst_info={},inst_tubi={},replace_exist={},write_inst_relate_aabb={}",
+            batch.batch_id,
+            batch.shape_insts.inst_info_map.len(),
+            batch.shape_insts.inst_tubi_map.len(),
+            batch.replace_exist,
+            batch.write_inst_relate_aabb
+        ));
+        let missing_neg_carriers = self
+            .injected_missing_neg
+            .lock()
+            .expect("recording lock")
+            .clone();
+        let missing_neg_count = missing_neg_carriers.len();
+        Ok(WriteBaseReport {
+            batch_id: batch.batch_id,
+            missing_neg_count,
+            missing_neg_carriers,
+        })
+    }
+
+    async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()> {
+        self.record(format!(
+            "persist_mesh_results:batch={},mesh_results={},file_mesh_state={}",
+            batch.batch_id,
+            batch.mesh_results.len(),
+            batch.file_mesh_state
+        ));
+        Ok(())
+    }
+
+    async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()> {
+        self.record(format!(
+            "write_inst_relate_aabb:batch={},mesh_results={},aabb_keys={}",
+            batch.batch_id,
+            batch.mesh_results.len(),
+            batch.mesh_aabb_map.len()
+        ));
+        Ok(())
+    }
+
+    async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize> {
+        self.record(format!(
+            "reconcile_missing_neg:all={},candidates={}",
+            request.all_refnos.len(),
+            request.candidate_carriers.len()
+        ));
+        Ok(*self
+            .injected_reconcile_inserted
+            .lock()
+            .expect("recording lock"))
+    }
+
+    async fn run_boolean_bridge(
+        &self,
+        request: BooleanBridgeRequest,
+    ) -> anyhow::Result<BooleanBridgeReport> {
+        self.record(format!(
+            "run_boolean_bridge:mode={:?},bool_tasks={}",
+            request.mode,
+            request.bool_tasks.len()
+        ));
+        Ok(BooleanBridgeReport::skipped(
+            "mock",
+            request.bool_tasks.len(),
+            "mock backend",
+        ))
+    }
+
+    async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary> {
+        self.record(format!(
+            "finalize:total_batches={},completed_batches={},mesh_cache_hits={},mesh_new_generated={},missing_neg_candidates={}",
+            request.total_batches,
+            request.completed_batches,
+            request.mesh_cache_hits,
+            request.mesh_new_generated,
+            request.missing_neg_candidates
+        ));
+        Ok(FinalizeSummary {
+            backend: self.name(),
+            total_batches: request.total_batches,
+            completed_batches: request.completed_batches,
+        })
+    }
+}

--- a/src/fast_model/gen_model/model_writer/mock.rs
+++ b/src/fast_model/gen_model/model_writer/mock.rs
@@ -49,10 +49,7 @@ impl ModelWriterBackend for RecordingBackend {
     }
 
     async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()> {
-        self.record(format!(
-            "cleanup:seed_refnos={}",
-            request.seed_refnos.len()
-        ));
+        self.record(format!("cleanup:seed_refnos={}", request.seed_refnos.len()));
         Ok(())
     }
 

--- a/src/fast_model/gen_model/model_writer/mod.rs
+++ b/src/fast_model/gen_model/model_writer/mod.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aios_core::RefnoEnum;
+use aios_core::geometry::ShapeInstancesData;
+use async_trait::async_trait;
+use dashmap::DashMap;
+use parry3d::bounding_volume::Aabb;
+
+use super::boolean_task::BooleanTask;
+use super::manifold_bool::BoolWorkerReport;
+use super::mesh_generate::MeshResult;
+use crate::options::{BooleanPipelineMode, DbOptionExt, ModelWriterMode};
+
+mod drain_only;
+#[cfg(feature = "model-writer-mock")]
+mod mock;
+mod surreal;
+
+pub use drain_only::{DrainOnlyModelWriterBackend, DrainOnlyStats, run_drain_only_sink};
+#[cfg(feature = "model-writer-mock")]
+pub use mock::RecordingBackend;
+pub use surreal::SurrealModelWriterBackend;
+
+#[derive(Debug, Clone)]
+pub struct ModelWriterContext {
+    pub project_name: String,
+    pub use_surrealdb: bool,
+    pub defer_db_write: bool,
+    pub mode: ModelWriterMode,
+}
+
+impl ModelWriterContext {
+    pub fn from_db_option(db_option: &DbOptionExt) -> Self {
+        Self {
+            project_name: db_option.inner.project_name.clone(),
+            use_surrealdb: db_option.use_surrealdb,
+            defer_db_write: db_option.defer_db_write,
+            mode: db_option.model_writer_mode,
+        }
+    }
+}
+
+pub struct BaseInstanceBatch<'a> {
+    pub batch_id: u64,
+    pub shape_insts: &'a ShapeInstancesData,
+    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
+    pub replace_exist: bool,
+    pub write_inst_relate_aabb: bool,
+}
+
+pub struct MeshResultBatch<'a> {
+    pub batch_id: u64,
+    pub mesh_results: &'a HashMap<u64, MeshResult>,
+    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
+    pub mesh_pts_map: &'a DashMap<u64, String>,
+    /// 来源于 `mesh_state::use_file_mesh_state()` 的进程级开关；显式塞进 batch
+    /// 让 trait 行为完全由参数决定（W3 修复）。
+    pub file_mesh_state: bool,
+}
+
+pub struct InstRelateAabbBatch<'a> {
+    pub batch_id: u64,
+    pub shape_insts: &'a ShapeInstancesData,
+    pub mesh_results: &'a HashMap<u64, MeshResult>,
+    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
+}
+
+pub struct CleanupRequest<'a> {
+    pub seed_refnos: &'a [RefnoEnum],
+}
+
+pub struct ReconcileRequest<'a> {
+    pub all_refnos: &'a [RefnoEnum],
+    pub candidate_carriers: &'a [RefnoEnum],
+}
+
+pub struct BooleanBridgeRequest {
+    pub mode: BooleanPipelineMode,
+    pub db_option: Arc<aios_core::options::DbOption>,
+    pub bool_tasks: Vec<BooleanTask>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BooleanBridgeReport {
+    pub pipeline: &'static str,
+    pub total: usize,
+    pub cata_cnt: usize,
+    pub inst_cnt: usize,
+    pub success: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub deferred_mode: bool,
+}
+
+impl BooleanBridgeReport {
+    pub(crate) fn db_legacy_executed() -> Self {
+        Self {
+            pipeline: "db_legacy",
+            total: 0,
+            cata_cnt: 0,
+            inst_cnt: 0,
+            success: 0,
+            failed: 0,
+            skipped: 0,
+            deferred_mode: false,
+        }
+    }
+
+    pub(crate) fn skipped(pipeline: &'static str, total: usize, reason: &str) -> Self {
+        println!(
+            "[model-writer:surreal] stage=boolean_bridge skipped pipeline={} reason={} total={}",
+            pipeline, reason, total
+        );
+        Self {
+            pipeline,
+            total,
+            cata_cnt: 0,
+            inst_cnt: 0,
+            success: 0,
+            failed: 0,
+            skipped: total,
+            deferred_mode: false,
+        }
+    }
+}
+
+impl From<BoolWorkerReport> for BooleanBridgeReport {
+    fn from(report: BoolWorkerReport) -> Self {
+        Self {
+            pipeline: "memory_tasks",
+            total: report.total,
+            cata_cnt: report.cata_cnt,
+            inst_cnt: report.inst_cnt,
+            success: report.success,
+            failed: report.failed,
+            skipped: report.skipped,
+            deferred_mode: report.deferred_mode,
+        }
+    }
+}
+
+/// `write_base_batch` 的对外 report，不耦合具体 backend 内部类型。
+///
+/// 字段名 `missing_neg_carriers` 与历史 `pdms_inst::SaveInstanceDataReport` 保持兼容，
+/// 让 orchestrator 调用代码改动量为 0。
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct WriteBaseReport {
+    pub batch_id: u64,
+    pub missing_neg_count: usize,
+    pub missing_neg_carriers: Vec<RefnoEnum>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FinalizeRequest {
+    pub total_batches: u64,
+    pub completed_batches: usize,
+    pub mesh_cache_hits: usize,
+    pub mesh_new_generated: usize,
+    pub missing_neg_candidates: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct FinalizeSummary {
+    pub backend: &'static str,
+    pub total_batches: u64,
+    pub completed_batches: usize,
+}
+
+#[async_trait]
+pub trait ModelWriterBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    async fn init(&self, context: &ModelWriterContext) -> anyhow::Result<()>;
+
+    async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()>;
+
+    async fn write_base_batch(
+        &self,
+        batch: BaseInstanceBatch<'_>,
+    ) -> anyhow::Result<WriteBaseReport>;
+
+    async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()>;
+
+    async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()>;
+
+    async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize>;
+
+    async fn run_boolean_bridge(
+        &self,
+        request: BooleanBridgeRequest,
+    ) -> anyhow::Result<BooleanBridgeReport>;
+
+    async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary>;
+}
+
+pub fn create_model_writer(db_option: &DbOptionExt) -> anyhow::Result<Arc<dyn ModelWriterBackend>> {
+    let backend: Arc<dyn ModelWriterBackend> = match db_option.model_writer_mode {
+        ModelWriterMode::Surreal => Arc::new(SurrealModelWriterBackend::default()),
+        ModelWriterMode::DrainOnly => Arc::new(DrainOnlyModelWriterBackend::default()),
+    };
+    println!(
+        "[model-writer] factory selected primary={} mirror=none fail_fast=true",
+        backend.name()
+    );
+    Ok(backend)
+}

--- a/src/fast_model/gen_model/model_writer/mod.rs
+++ b/src/fast_model/gen_model/model_writer/mod.rs
@@ -12,14 +12,23 @@ use super::manifold_bool::BoolWorkerReport;
 use super::mesh_generate::MeshResult;
 use crate::options::{BooleanPipelineMode, DbOptionExt, ModelWriterMode};
 
+pub use super::canonical_records::{
+    CanonicalRawBatch, CanonicalRawPlanner, CanonicalRawRowCounts, CanonicalRawTable,
+};
+
 mod drain_only;
 #[cfg(feature = "model-writer-mock")]
 mod mock;
+mod parquet;
 mod surreal;
 
 pub use drain_only::{DrainOnlyModelWriterBackend, DrainOnlyStats, run_drain_only_sink};
 #[cfg(feature = "model-writer-mock")]
 pub use mock::RecordingBackend;
+pub use parquet::{
+    CanonicalParquetBatchSummary, CanonicalParquetTableSummary, CanonicalParquetWriter,
+    CanonicalParquetWriterConfig,
+};
 pub use surreal::SurrealModelWriterBackend;
 
 #[derive(Debug, Clone)]

--- a/src/fast_model/gen_model/model_writer/mod.rs
+++ b/src/fast_model/gen_model/model_writer/mod.rs
@@ -26,8 +26,7 @@ pub use drain_only::{DrainOnlyModelWriterBackend, DrainOnlyStats, run_drain_only
 #[cfg(feature = "model-writer-mock")]
 pub use mock::RecordingBackend;
 pub use parquet::{
-    CanonicalParquetBatchSummary, CanonicalParquetTableSummary, CanonicalParquetWriter,
-    CanonicalParquetWriterConfig,
+    CanonicalParquetTableSummary, CanonicalParquetWriter, CanonicalParquetWriterConfig,
 };
 pub use surreal::SurrealModelWriterBackend;
 

--- a/src/fast_model/gen_model/model_writer/mod.rs
+++ b/src/fast_model/gen_model/model_writer/mod.rs
@@ -12,6 +12,8 @@ use super::manifold_bool::BoolWorkerReport;
 use super::mesh_generate::MeshResult;
 use crate::options::{BooleanPipelineMode, DbOptionExt, ModelWriterMode};
 
+// Canonical raw record types & planner; sits below trait backends (parallel
+// canonical raw boundary work, see docs/development/model-writer-storage/).
 pub use super::canonical_records::{
     CanonicalRawBatch, CanonicalRawPlanner, CanonicalRawRowCounts, CanonicalRawTable,
 };
@@ -25,6 +27,7 @@ mod surreal;
 pub use drain_only::{DrainOnlyModelWriterBackend, DrainOnlyStats, run_drain_only_sink};
 #[cfg(feature = "model-writer-mock")]
 pub use mock::RecordingBackend;
+// Canonical raw sink scaffold (not a ModelWriterBackend impl; not in factory).
 pub use parquet::{
     CanonicalParquetTableSummary, CanonicalParquetWriter, CanonicalParquetWriterConfig,
 };
@@ -85,6 +88,8 @@ pub struct ReconcileRequest<'a> {
 
 pub struct BooleanBridgeRequest {
     pub mode: BooleanPipelineMode,
+    // TODO(P5): replace with a minimal BridgeContext to remove DbOption coupling
+    // from the trait surface. See findings.md §3 (decision: keep short-term).
     pub db_option: Arc<aios_core::options::DbOption>,
     pub bool_tasks: Vec<BooleanTask>,
 }
@@ -117,8 +122,8 @@ impl BooleanBridgeReport {
 
     pub(crate) fn skipped(pipeline: &'static str, total: usize, reason: &str) -> Self {
         println!(
-            "[model-writer:surreal] stage=boolean_bridge skipped pipeline={} reason={} total={}",
-            pipeline, reason, total
+            "[model-writer:{}] stage=boolean_bridge skipped pipeline={} reason={} total={}",
+            pipeline, pipeline, reason, total
         );
         Self {
             pipeline,
@@ -153,10 +158,15 @@ impl From<BoolWorkerReport> for BooleanBridgeReport {
 /// 字段名 `missing_neg_carriers` 与历史 `pdms_inst::SaveInstanceDataReport` 保持兼容，
 /// 让 orchestrator 调用代码改动量为 0。
 #[derive(Debug, Clone, Default)]
-#[non_exhaustive]
 pub struct WriteBaseReport {
     pub batch_id: u64,
     pub missing_neg_count: usize,
+    /// 历史调用方需要的 `RefnoEnum` 集合，由 backend 在写 base batch 时收集。
+    ///
+    /// 这是 trait 接口里唯一仍带 `aios_core::RefnoEnum` 的字段，等同于把
+    /// "missing-neg 收集" 语义抬到 trait 层。P5 backlog (`T5.1`) 计划把这个字段
+    /// 拆为独立 trait 方法 `take_missing_neg_carriers(&self) -> Vec<RefnoEnum>`，
+    /// 让 backend 决定是否暴露 carriers；当前先保留以减少本 PR 的接口侵入面。
     pub missing_neg_carriers: Vec<RefnoEnum>,
 }
 

--- a/src/fast_model/gen_model/model_writer/parquet.rs
+++ b/src/fast_model/gen_model/model_writer/parquet.rs
@@ -1,0 +1,245 @@
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::Serialize;
+
+use super::CanonicalRawBatch;
+use crate::fast_model::gen_model::canonical_records::CanonicalRawTable;
+
+/// File-oriented canonical writer scaffold for the future Parquet backend.
+///
+/// This phase keeps the boundary isolated from production `ModelWriterBackend`
+/// selection and emits JSON Lines files with the same table layout the Parquet
+/// writer will own. Typed Parquet materialization remains gated to the next
+/// phase so the current Surreal/default path is not affected by heavy optional
+/// Parquet/Polars dependencies.
+#[derive(Debug, Clone)]
+pub struct CanonicalParquetWriter {
+    config: CanonicalParquetWriterConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct CanonicalParquetWriterConfig {
+    pub output_dir: PathBuf,
+    pub project_name: String,
+    pub dbnum: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CanonicalParquetBatchSummary {
+    pub backend: &'static str,
+    pub format: &'static str,
+    pub limitation: &'static str,
+    pub project_name: String,
+    pub dbnum: u32,
+    pub batch_id: u64,
+    pub raw_root: String,
+    pub tables: Vec<CanonicalParquetTableSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CanonicalParquetTableSummary {
+    pub table: &'static str,
+    pub rows: usize,
+    pub path: String,
+    pub limitation: Option<&'static str>,
+}
+
+impl CanonicalParquetWriter {
+    pub fn new(config: CanonicalParquetWriterConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn write_raw_batch(
+        &self,
+        batch_id: u64,
+        batch: &CanonicalRawBatch,
+    ) -> anyhow::Result<CanonicalParquetBatchSummary> {
+        let raw_root = self
+            .config
+            .output_dir
+            .join("model_writer_storage")
+            .join("raw");
+        fs::create_dir_all(&raw_root).with_context(|| {
+            format!(
+                "failed to create canonical parquet raw root {}",
+                raw_root.display()
+            )
+        })?;
+
+        let mut tables = Vec::new();
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawInstInfo,
+            batch_id,
+            &batch.inst_info,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawInstRelate,
+            batch_id,
+            &batch.inst_relate,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawInstGeo,
+            batch_id,
+            &batch.inst_geo,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawGeoRelate,
+            batch_id,
+            &batch.geo_relate,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawTubiInfo,
+            batch_id,
+            &batch.tubi_info,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawTubiRelate,
+            batch_id,
+            &batch.tubi_relate,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawNegRelate,
+            batch_id,
+            &batch.neg_relate,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawNgmrRelate,
+            batch_id,
+            &batch.ngmr_relate,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawAabb,
+            batch_id,
+            &batch.aabb,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawTrans,
+            batch_id,
+            &batch.trans,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawVec3,
+            batch_id,
+            &batch.vec3,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawInstRelateAabb,
+            batch_id,
+            &batch.inst_relate_aabb,
+        )?);
+        tables.push(self.write_table(
+            &raw_root,
+            CanonicalRawTable::RawRefnoAssocIndex,
+            batch_id,
+            &batch.refno_assoc_index,
+        )?);
+
+        let summary = CanonicalParquetBatchSummary {
+            backend: "parquet-canonical",
+            format: "jsonl-fallback",
+            limitation: "typed parquet materialization is intentionally deferred; this scaffold preserves canonical table boundaries and row counts",
+            project_name: self.config.project_name.clone(),
+            dbnum: self.config.dbnum,
+            batch_id,
+            raw_root: raw_root.display().to_string(),
+            tables,
+        };
+        self.write_summary(batch_id, &summary)?;
+        Ok(summary)
+    }
+
+    fn write_table<T: Serialize>(
+        &self,
+        raw_root: &Path,
+        table: CanonicalRawTable,
+        batch_id: u64,
+        rows: &[T],
+    ) -> anyhow::Result<CanonicalParquetTableSummary> {
+        let path = self.table_file_path(raw_root, table, batch_id);
+        write_json_lines(&path, rows)?;
+        Ok(CanonicalParquetTableSummary {
+            table: table.as_str(),
+            rows: rows.len(),
+            path: path.display().to_string(),
+            limitation: table.phase1_limitation(),
+        })
+    }
+
+    fn write_empty_table<T: Serialize>(
+        &self,
+        raw_root: &Path,
+        table: CanonicalRawTable,
+        batch_id: u64,
+        rows: &[T],
+    ) -> anyhow::Result<CanonicalParquetTableSummary> {
+        self.write_table(raw_root, table, batch_id, rows)
+    }
+
+    fn table_file_path(&self, raw_root: &Path, table: CanonicalRawTable, batch_id: u64) -> PathBuf {
+        raw_root
+            .join(table.as_str())
+            .join(format!("project_name={}", self.config.project_name))
+            .join(format!("dbnum={}", self.config.dbnum))
+            .join(format!("batch_{batch_id}.jsonl"))
+    }
+
+    fn write_summary(
+        &self,
+        batch_id: u64,
+        summary: &CanonicalParquetBatchSummary,
+    ) -> anyhow::Result<()> {
+        let summary_dir = self
+            .config
+            .output_dir
+            .join("model_writer_storage")
+            .join("summary")
+            .join(format!("project_name={}", self.config.project_name))
+            .join(format!("dbnum={}", self.config.dbnum));
+        fs::create_dir_all(&summary_dir).with_context(|| {
+            format!(
+                "failed to create canonical parquet summary dir {}",
+                summary_dir.display()
+            )
+        })?;
+        let path = summary_dir.join(format!("batch_{batch_id}.json"));
+        let file = File::create(&path)
+            .with_context(|| format!("failed to create summary file {}", path.display()))?;
+        serde_json::to_writer_pretty(BufWriter::new(file), summary)
+            .with_context(|| format!("failed to write summary file {}", path.display()))
+    }
+}
+
+fn write_json_lines<T: Serialize>(path: &Path, rows: &[T]) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create table dir {}", parent.display()))?;
+    }
+    let file = File::create(path)
+        .with_context(|| format!("failed to create table file {}", path.display()))?;
+    let mut writer = BufWriter::new(file);
+    for row in rows {
+        serde_json::to_writer(&mut writer, row)
+            .with_context(|| format!("failed to serialize row for {}", path.display()))?;
+        writer
+            .write_all(b"\n")
+            .with_context(|| format!("failed to write row for {}", path.display()))?;
+    }
+    writer
+        .flush()
+        .with_context(|| format!("failed to flush table file {}", path.display()))
+}

--- a/src/fast_model/gen_model/model_writer/parquet.rs
+++ b/src/fast_model/gen_model/model_writer/parquet.rs
@@ -32,10 +32,12 @@ pub struct CanonicalParquetBatchSummary {
     pub backend: &'static str,
     pub format: &'static str,
     pub limitation: &'static str,
+    pub summary_path: String,
     pub project_name: String,
     pub dbnum: u32,
     pub batch_id: u64,
     pub raw_root: String,
+    pub total_rows: usize,
     pub tables: Vec<CanonicalParquetTableSummary>,
 }
 
@@ -149,17 +151,21 @@ impl CanonicalParquetWriter {
             &batch.refno_assoc_index,
         )?);
 
+        let summary_path = self.summary_file_path(batch_id);
+        let total_rows = tables.iter().map(|table| table.rows).sum();
         let summary = CanonicalParquetBatchSummary {
             backend: "parquet-canonical",
             format: "jsonl-fallback",
             limitation: "typed parquet materialization is intentionally deferred; this scaffold preserves canonical table boundaries and row counts",
+            summary_path: stable_path_string(&summary_path),
             project_name: self.config.project_name.clone(),
             dbnum: self.config.dbnum,
             batch_id,
-            raw_root: raw_root.display().to_string(),
+            raw_root: stable_path_string(&raw_root),
+            total_rows,
             tables,
         };
-        self.write_summary(batch_id, &summary)?;
+        self.write_summary(&summary_path, &summary)?;
         Ok(summary)
     }
 
@@ -175,19 +181,9 @@ impl CanonicalParquetWriter {
         Ok(CanonicalParquetTableSummary {
             table: table.as_str(),
             rows: rows.len(),
-            path: path.display().to_string(),
+            path: stable_path_string(&path),
             limitation: table.phase1_limitation(),
         })
-    }
-
-    fn write_empty_table<T: Serialize>(
-        &self,
-        raw_root: &Path,
-        table: CanonicalRawTable,
-        batch_id: u64,
-        rows: &[T],
-    ) -> anyhow::Result<CanonicalParquetTableSummary> {
-        self.write_table(raw_root, table, batch_id, rows)
     }
 
     fn table_file_path(&self, raw_root: &Path, table: CanonicalRawTable, batch_id: u64) -> PathBuf {
@@ -198,30 +194,42 @@ impl CanonicalParquetWriter {
             .join(format!("batch_{batch_id}.jsonl"))
     }
 
-    fn write_summary(
-        &self,
-        batch_id: u64,
-        summary: &CanonicalParquetBatchSummary,
-    ) -> anyhow::Result<()> {
-        let summary_dir = self
-            .config
+    pub fn summary_file_path(&self, batch_id: u64) -> PathBuf {
+        self.config
             .output_dir
             .join("model_writer_storage")
             .join("summary")
             .join(format!("project_name={}", self.config.project_name))
-            .join(format!("dbnum={}", self.config.dbnum));
-        fs::create_dir_all(&summary_dir).with_context(|| {
+            .join(format!("dbnum={}", self.config.dbnum))
+            .join(format!("batch_{batch_id}.json"))
+    }
+
+    fn write_summary(
+        &self,
+        path: &Path,
+        summary: &CanonicalParquetBatchSummary,
+    ) -> anyhow::Result<()> {
+        let summary_dir = path.parent().with_context(|| {
+            format!(
+                "failed to determine canonical parquet summary dir for {}",
+                path.display()
+            )
+        })?;
+        fs::create_dir_all(summary_dir).with_context(|| {
             format!(
                 "failed to create canonical parquet summary dir {}",
                 summary_dir.display()
             )
         })?;
-        let path = summary_dir.join(format!("batch_{batch_id}.json"));
-        let file = File::create(&path)
+        let file = File::create(path)
             .with_context(|| format!("failed to create summary file {}", path.display()))?;
         serde_json::to_writer_pretty(BufWriter::new(file), summary)
             .with_context(|| format!("failed to write summary file {}", path.display()))
     }
+}
+
+fn stable_path_string(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
 }
 
 fn write_json_lines<T: Serialize>(path: &Path, rows: &[T]) -> anyhow::Result<()> {

--- a/src/fast_model/gen_model/model_writer/parquet.rs
+++ b/src/fast_model/gen_model/model_writer/parquet.rs
@@ -1,3 +1,12 @@
+//! Phase 1 canonical raw sink scaffold. **NOT a `ModelWriterBackend` impl.**
+//!
+//! 与 `surreal.rs` / `drain_only.rs` 不同，本文件不实现 trait、也不进 `create_model_writer`
+//! 工厂。它属于 `docs/development/model-writer-storage/` 描述的"canonical raw boundary"
+//! 平行工作流：在 trait backend 之下、`canonical_records.rs` 之上承担文件 sink 角色，
+//! 当前阶段输出 JSON Lines 以保留 layout，后续 Phase 5 才考虑升级为 typed Parquet 并
+//! 接入 trait 工厂。位置放在 `model_writer/` 是为了未来收口顺手；若让人困惑，可移到
+//! `canonical_records/` 子目录。
+
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};

--- a/src/fast_model/gen_model/model_writer/surreal.rs
+++ b/src/fast_model/gen_model/model_writer/surreal.rs
@@ -1,202 +1,32 @@
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::sync::OnceLock;
 
 use aios_core::error::init_save_database_error;
-use aios_core::geometry::ShapeInstancesData;
-use aios_core::{RefnoEnum, model_primary_db};
+use aios_core::model_primary_db;
 use anyhow::Context;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use parry3d::bounding_volume::Aabb;
 
-use super::boolean_task::BooleanTask;
-use super::manifold_bool::{BoolWorkerReport, run_bool_worker_from_tasks};
-use super::mesh_generate::{MeshResult, run_boolean_worker};
-use super::mesh_state::{flush_aabb_cache, use_file_mesh_state};
-use super::pdms_inst::{self, SaveInstanceDataReport};
-use super::pdms_inst_surreal;
-use crate::options::{BooleanPipelineMode, DbOptionExt, ModelWriterMode};
-
-#[derive(Debug, Clone)]
-pub struct ModelWriterContext {
-    pub project_name: String,
-    pub use_surrealdb: bool,
-    pub defer_db_write: bool,
-    pub mode: ModelWriterMode,
-}
-
-impl ModelWriterContext {
-    pub fn from_db_option(db_option: &DbOptionExt) -> Self {
-        Self {
-            project_name: db_option.inner.project_name.clone(),
-            use_surrealdb: db_option.use_surrealdb,
-            defer_db_write: db_option.defer_db_write,
-            mode: db_option.model_writer_mode,
-        }
-    }
-}
-
-pub struct BaseInstanceBatch<'a> {
-    pub batch_id: u64,
-    pub shape_insts: &'a ShapeInstancesData,
-    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
-    pub replace_exist: bool,
-    pub write_inst_relate_aabb: bool,
-}
-
-pub struct MeshResultBatch<'a> {
-    pub batch_id: u64,
-    pub mesh_results: &'a HashMap<u64, MeshResult>,
-    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
-    pub mesh_pts_map: &'a DashMap<u64, String>,
-}
-
-pub struct InstRelateAabbBatch<'a> {
-    pub batch_id: u64,
-    pub shape_insts: &'a ShapeInstancesData,
-    pub mesh_results: &'a HashMap<u64, MeshResult>,
-    pub mesh_aabb_map: &'a DashMap<String, Aabb>,
-}
-
-pub struct CleanupRequest<'a> {
-    pub seed_refnos: &'a [RefnoEnum],
-}
-
-pub struct ReconcileRequest<'a> {
-    pub all_refnos: &'a [RefnoEnum],
-    pub candidate_carriers: &'a [RefnoEnum],
-}
-
-pub struct BooleanBridgeRequest {
-    pub mode: BooleanPipelineMode,
-    pub db_option: Arc<aios_core::options::DbOption>,
-    pub bool_tasks: Vec<BooleanTask>,
-    pub use_surrealdb: bool,
-    pub defer_db_write: bool,
-}
-
-#[derive(Debug, Clone)]
-pub struct BooleanBridgeReport {
-    pub pipeline: &'static str,
-    pub total: usize,
-    pub cata_cnt: usize,
-    pub inst_cnt: usize,
-    pub success: usize,
-    pub failed: usize,
-    pub skipped: usize,
-    pub deferred_mode: bool,
-}
-
-impl BooleanBridgeReport {
-    fn db_legacy_executed() -> Self {
-        Self {
-            pipeline: "db_legacy",
-            total: 0,
-            cata_cnt: 0,
-            inst_cnt: 0,
-            success: 0,
-            failed: 0,
-            skipped: 0,
-            deferred_mode: false,
-        }
-    }
-
-    fn skipped(pipeline: &'static str, total: usize, reason: &str) -> Self {
-        println!(
-            "[model-writer:surreal] stage=boolean_bridge skipped pipeline={} reason={} total={}",
-            pipeline, reason, total
-        );
-        Self {
-            pipeline,
-            total,
-            cata_cnt: 0,
-            inst_cnt: 0,
-            success: 0,
-            failed: 0,
-            skipped: total,
-            deferred_mode: false,
-        }
-    }
-}
-
-impl From<BoolWorkerReport> for BooleanBridgeReport {
-    fn from(report: BoolWorkerReport) -> Self {
-        Self {
-            pipeline: "memory_tasks",
-            total: report.total,
-            cata_cnt: report.cata_cnt,
-            inst_cnt: report.inst_cnt,
-            success: report.success,
-            failed: report.failed,
-            skipped: report.skipped,
-            deferred_mode: report.deferred_mode,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct FinalizeRequest {
-    pub total_batches: u64,
-    pub completed_batches: usize,
-    pub mesh_cache_hits: usize,
-    pub mesh_new_generated: usize,
-    pub missing_neg_candidates: usize,
-}
-
-#[derive(Debug, Clone)]
-pub struct FinalizeSummary {
-    pub backend: &'static str,
-    pub total_batches: u64,
-    pub completed_batches: usize,
-}
-
-#[async_trait]
-pub trait ModelWriteBackend: Send + Sync {
-    fn name(&self) -> &'static str;
-
-    async fn init(&self, context: &ModelWriterContext) -> anyhow::Result<()>;
-
-    async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()>;
-
-    async fn write_base_batch(
-        &self,
-        batch: BaseInstanceBatch<'_>,
-    ) -> anyhow::Result<SaveInstanceDataReport>;
-
-    async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()>;
-
-    async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()>;
-
-    async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize>;
-
-    async fn run_boolean_bridge(
-        &self,
-        request: BooleanBridgeRequest,
-    ) -> anyhow::Result<BooleanBridgeReport>;
-
-    async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary>;
-}
-
-pub fn create_model_writer(db_option: &DbOptionExt) -> anyhow::Result<Arc<dyn ModelWriteBackend>> {
-    match db_option.model_writer_mode {
-        ModelWriterMode::Surreal => {
-            println!("[model-writer] factory selected primary=surreal mirror=none fail_fast=true");
-            Ok(Arc::new(SurrealModelWriteBackend))
-        }
-        ModelWriterMode::DrainOnly => {
-            anyhow::bail!(
-                "drain-only is an explicit non-persistent sink and does not create a persistence backend"
-            )
-        }
-    }
-}
+use super::super::manifold_bool::run_bool_worker_from_tasks;
+use super::super::mesh_generate::{MeshResult, run_boolean_worker};
+use super::super::mesh_state::flush_aabb_cache;
+use super::super::pdms_inst::{self};
+use super::super::pdms_inst_surreal;
+use super::{
+    BaseInstanceBatch, BooleanBridgeReport, BooleanBridgeRequest, CleanupRequest, FinalizeRequest,
+    FinalizeSummary, InstRelateAabbBatch, MeshResultBatch, ModelWriterBackend, ModelWriterContext,
+    ReconcileRequest, WriteBaseReport,
+};
+use crate::options::BooleanPipelineMode;
 
 #[derive(Debug, Default)]
-pub struct SurrealModelWriteBackend;
+pub struct SurrealModelWriterBackend {
+    context: OnceLock<ModelWriterContext>,
+}
 
 #[async_trait]
-impl ModelWriteBackend for SurrealModelWriteBackend {
+impl ModelWriterBackend for SurrealModelWriterBackend {
     fn name(&self) -> &'static str {
         "surreal"
     }
@@ -211,11 +41,12 @@ impl ModelWriteBackend for SurrealModelWriteBackend {
         );
         anyhow::ensure!(
             context.use_surrealdb,
-            "Surreal model writer requires use_surrealdb=true for the current input/write contract"
+            "Surreal model writer requires use_surrealdb=true (defense-in-depth)"
         );
         aios_core::rs_surreal::inst::init_model_tables()
             .await
             .context("model_writer surreal init_model_tables failed")?;
+        let _ = self.context.set(context.clone());
         Ok(())
     }
 
@@ -240,7 +71,7 @@ impl ModelWriteBackend for SurrealModelWriteBackend {
     async fn write_base_batch(
         &self,
         batch: BaseInstanceBatch<'_>,
-    ) -> anyhow::Result<SaveInstanceDataReport> {
+    ) -> anyhow::Result<WriteBaseReport> {
         println!(
             "[model-writer:surreal] stage=base batch={} inst_info={} inst_tubi={} geo_keys={}",
             batch.batch_id,
@@ -258,16 +89,20 @@ impl ModelWriteBackend for SurrealModelWriteBackend {
         )
         .await
         .with_context(|| format!("model_writer surreal base batch {} failed", batch.batch_id))?;
+        let missing_neg_count = report.missing_neg_carriers.len();
         println!(
             "[model-writer:surreal] stage=base batch={} done missing_neg_candidates={}",
-            batch.batch_id,
-            report.missing_neg_carriers.len()
+            batch.batch_id, missing_neg_count
         );
-        Ok(report)
+        Ok(WriteBaseReport {
+            batch_id: batch.batch_id,
+            missing_neg_count,
+            missing_neg_carriers: report.missing_neg_carriers,
+        })
     }
 
     async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()> {
-        if use_file_mesh_state() {
+        if batch.file_mesh_state {
             flush_aabb_cache();
             println!(
                 "[model-writer:surreal] stage=mesh_results batch={} file_mesh_state=true flushed_aabb_cache=true",
@@ -378,9 +213,16 @@ impl ModelWriteBackend for SurrealModelWriteBackend {
         &self,
         request: BooleanBridgeRequest,
     ) -> anyhow::Result<BooleanBridgeReport> {
+        let Some(ctx) = self.context.get() else {
+            return Ok(BooleanBridgeReport::skipped(
+                "uninitialized",
+                request.bool_tasks.len(),
+                "init not called before run_boolean_bridge",
+            ));
+        };
         match request.mode {
             BooleanPipelineMode::DbLegacy => {
-                if request.use_surrealdb && !request.defer_db_write {
+                if ctx.use_surrealdb && !ctx.defer_db_write {
                     println!("[model-writer:surreal] stage=boolean_bridge pipeline=db_legacy");
                     run_boolean_worker(request.db_option, 100)
                         .await
@@ -395,7 +237,7 @@ impl ModelWriteBackend for SurrealModelWriteBackend {
                 }
             }
             BooleanPipelineMode::MemoryTasks => {
-                if !request.use_surrealdb {
+                if !ctx.use_surrealdb {
                     return Ok(BooleanBridgeReport::skipped(
                         "memory_tasks",
                         request.bool_tasks.len(),
@@ -432,6 +274,37 @@ impl ModelWriteBackend for SurrealModelWriteBackend {
     }
 }
 
+/// SurrealDB record id 的安全包装。
+///
+/// 构造时强制 ASCII alphanum + `:` / `_` / `-`，禁止任意 String，避免
+/// SQL 拼接被外部输入污染。当前 record id 来源是内部 mesh hash，
+/// 该约束**不会**拒绝合法 key；如需扩展字符集（如 UTF-8 哈希），改这里。
+struct SurrealRecordKey(String);
+
+impl SurrealRecordKey {
+    fn new(table: &'static str, raw_key: &str) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            raw_key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '_' | '-')),
+            "SurrealRecordKey rejects non-ASCII raw_key for table {}: {:?}",
+            table,
+            raw_key
+        );
+        let prefix = format!("{}:", table);
+        let id = if raw_key.starts_with(&prefix) {
+            raw_key.to_string()
+        } else {
+            format!("{}⟨{}⟩", prefix, raw_key)
+        };
+        Ok(Self(id))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 async fn save_aabb_to_surreal_strict(aabb_map: &DashMap<String, Aabb>) -> anyhow::Result<usize> {
     if aabb_map.is_empty() {
         return Ok(0);
@@ -449,12 +322,8 @@ async fn save_aabb_to_surreal_strict(aabb_map: &DashMap<String, Aabb>) -> anyhow
                 continue;
             };
             let d = serde_json::to_string(v.value())?;
-            let id_key = if k.starts_with("aabb:") {
-                k.to_string()
-            } else {
-                format!("aabb:⟨{}⟩", k)
-            };
-            rows.push(format!("{{'id':{id_key}, 'd':{d}}}"));
+            let id_key = SurrealRecordKey::new("aabb", k)?;
+            rows.push(format!("{{'id':{}, 'd':{d}}}", id_key.as_str()));
         }
         if rows.is_empty() {
             continue;
@@ -485,7 +354,8 @@ async fn save_pts_to_surreal_strict(vec3_map: &DashMap<u64, String>) -> anyhow::
             let Some(v) = vec3_map.get(&k) else {
                 continue;
             };
-            rows.push(format!("{{'id':vec3:⟨{}⟩, 'd':{}}}", k, v.value()));
+            let id_key = SurrealRecordKey::new("vec3", &k.to_string())?;
+            rows.push(format!("{{'id':{}, 'd':{}}}", id_key.as_str(), v.value()));
         }
         if rows.is_empty() {
             continue;
@@ -501,77 +371,4 @@ async fn save_pts_to_surreal_strict(vec3_map: &DashMap<u64, String>) -> anyhow::
         written += rows.len();
     }
     Ok(written)
-}
-
-#[derive(Debug, Default)]
-pub struct DrainOnlyStats {
-    pub batches: usize,
-    pub instances: usize,
-    pub inst_info: usize,
-    pub inst_tubi: usize,
-    pub geo_keys: usize,
-    pub geo_instances: usize,
-    pub neg_relations: usize,
-    pub ngmr_relations: usize,
-    pub elapsed: Duration,
-}
-
-impl DrainOnlyStats {
-    fn add_batch(&mut self, batch: &ShapeInstancesData) {
-        self.batches += 1;
-        self.instances += batch.inst_cnt();
-        self.inst_info += batch.inst_info_map.len();
-        self.inst_tubi += batch.inst_tubi_map.len();
-        self.geo_keys += batch.inst_geos_map.len();
-        self.geo_instances += batch
-            .inst_geos_map
-            .values()
-            .map(|geos| geos.insts.len())
-            .sum::<usize>();
-        self.neg_relations += batch.neg_relate_map.values().map(Vec::len).sum::<usize>();
-        self.ngmr_relations += batch
-            .ngmr_neg_relate_map
-            .values()
-            .map(Vec::len)
-            .sum::<usize>();
-    }
-
-    pub fn print_summary(&self) {
-        println!(
-            "[model-writer:drain-only] summary: batches={} instances={} inst_info={} inst_tubi={} geo_keys={} geo_instances={} neg_relations={} ngmr_relations={} elapsed_ms={}",
-            self.batches,
-            self.instances,
-            self.inst_info,
-            self.inst_tubi,
-            self.geo_keys,
-            self.geo_instances,
-            self.neg_relations,
-            self.ngmr_relations,
-            self.elapsed.as_millis()
-        );
-    }
-}
-
-pub async fn run_drain_only_sink(
-    receiver: flume::Receiver<ShapeInstancesData>,
-) -> anyhow::Result<DrainOnlyStats> {
-    let started = Instant::now();
-    let mut stats = DrainOnlyStats::default();
-
-    while let Ok(batch) = receiver.recv_async().await {
-        stats.add_batch(&batch);
-
-        if stats.batches % 100 == 0 {
-            println!(
-                "[model-writer:drain-only] drained batches={} instances={} geo_instances={} elapsed_ms={}",
-                stats.batches,
-                stats.instances,
-                stats.geo_instances,
-                started.elapsed().as_millis()
-            );
-        }
-    }
-
-    stats.elapsed = started.elapsed();
-    Ok(stats)
 }

--- a/src/fast_model/gen_model/model_writer/surreal.rs
+++ b/src/fast_model/gen_model/model_writer/surreal.rs
@@ -276,9 +276,13 @@ impl ModelWriterBackend for SurrealModelWriterBackend {
 
 /// SurrealDB record id 的安全包装。
 ///
-/// 构造时强制 ASCII alphanum + `:` / `_` / `-`，禁止任意 String，避免
-/// SQL 拼接被外部输入污染。当前 record id 来源是内部 mesh hash，
-/// 该约束**不会**拒绝合法 key；如需扩展字符集（如 UTF-8 哈希），改这里。
+/// 构造时强制 ASCII alphanum + `_` / `-`（注意：`:` 被排除以确保 raw_key
+/// **不能**包含表前缀），禁止任意 String，避免 SQL 拼接被外部输入污染。
+/// 当前 record id 来源是内部 mesh hash，该约束**不会**拒绝合法 key；如需
+/// 扩展字符集（如 UTF-8 哈希），改这里。
+///
+/// 输出统一为 `table:⟨raw_key⟩` 形式（SurrealDB escaped record id 语法），
+/// 避免不同分支产出 `table:raw_key` 与 `table:⟨raw_key⟩` 两种格式不一致。
 struct SurrealRecordKey(String);
 
 impl SurrealRecordKey {
@@ -286,18 +290,12 @@ impl SurrealRecordKey {
         anyhow::ensure!(
             raw_key
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '_' | '-')),
-            "SurrealRecordKey rejects non-ASCII raw_key for table {}: {:?}",
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-')),
+            "SurrealRecordKey rejects raw_key (must be ASCII alphanum / `_` / `-`, no `:`) for table {}: {:?}",
             table,
             raw_key
         );
-        let prefix = format!("{}:", table);
-        let id = if raw_key.starts_with(&prefix) {
-            raw_key.to_string()
-        } else {
-            format!("{}⟨{}⟩", prefix, raw_key)
-        };
-        Ok(Self(id))
+        Ok(Self(format!("{}:⟨{}⟩", table, raw_key)))
     }
 
     fn as_str(&self) -> &str {

--- a/src/fast_model/gen_model/orchestrator.rs
+++ b/src/fast_model/gen_model/orchestrator.rs
@@ -11,7 +11,6 @@ use crate::fast_model::export_model::export_prepack_lod::export_instances_json_f
 use crate::fast_model::export_model::export_prepack_lod::export_instances_json_for_refnos_grouped_by_dbno;
 use crate::fast_model::export_model::export_prepack_lod::export_prepack_lod_for_refnos;
 use crate::fast_model::unit_converter::LengthUnit;
-use crate::fast_model::utils::{save_aabb_to_surreal, save_pts_to_surreal};
 use aios_core::RefnoEnum;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -20,17 +19,12 @@ use std::time::Instant;
 // use crate::fast_model::capture::capture_refnos_if_enabled; // removed on foyer-cache-cleanup
 use crate::data_interface::db_meta_manager::db_meta;
 use crate::fast_model::gen_model::boolean_task::{BooleanTask, BooleanTaskAccumulator};
-use crate::fast_model::gen_model::manifold_bool::run_bool_worker_from_tasks;
-use crate::fast_model::gen_model::mesh_state::{flush_aabb_cache, use_file_mesh_state};
 use crate::fast_model::gen_model::model_writer::{
-    ModelWriter, ModelWriterFinishReport, create_model_writer, run_model_writer_sink,
+    BaseInstanceBatch, BooleanBridgeRequest, FinalizeRequest, InstRelateAabbBatch, MeshResultBatch,
+    ModelWriteBackend, ModelWriterContext, ReconcileRequest, create_model_writer,
+    run_drain_only_sink,
 };
-use crate::fast_model::mesh_generate::{
-    MeshResult, query_existing_meshed_inst_geo_ids, run_boolean_worker,
-};
-use crate::fast_model::pdms_inst::{
-    build_inst_relate_aabb_rows, reconcile_missing_neg_relate, save_inst_relate_aabb_rows,
-};
+use crate::fast_model::mesh_generate::{MeshResult, query_existing_meshed_inst_geo_ids};
 use crate::options::{BooleanPipelineMode, DbOptionExt, MeshFormat, ModelWriterMode};
 use dashmap::DashMap;
 use flume::{Receiver, Sender};
@@ -477,37 +471,45 @@ async fn run_base_writer(
     receiver: Receiver<PipelineBatch>,
     result_sender: Sender<(u64, u128, u128)>,
     base_write_semaphore: Arc<Semaphore>,
-    worker_count: usize,
-    model_writer: Arc<dyn ModelWriter>,
-) -> anyhow::Result<ModelWriterFinishReport> {
+    mesh_aabb_map: Arc<DashMap<String, parry3d::bounding_volume::Aabb>>,
+    missing_neg_carriers: Arc<std::sync::Mutex<HashSet<RefnoEnum>>>,
+    model_writer: Arc<dyn ModelWriteBackend>,
+) -> anyhow::Result<()> {
     let mut handles = Vec::new();
-    let worker_count = worker_count.max(1);
-    println!("[batch_stage] stage=base worker_pool={}", worker_count);
-    model_writer.prepare().await?;
-    for worker_id in 0..worker_count {
-        let receiver = receiver.clone();
+    while let Ok(batch) = receiver.recv_async().await {
         let semaphore = base_write_semaphore.clone();
+        let mesh_aabb_map = mesh_aabb_map.clone();
         let result_sender = result_sender.clone();
+        let missing_neg_carriers = missing_neg_carriers.clone();
         let model_writer = model_writer.clone();
         handles.push(tokio::spawn(async move {
-            while let Ok(batch) = receiver.recv_async().await {
-                let (permit, wait_ms) = acquire_with_wait(semaphore.clone()).await?;
-                let base_start = Instant::now();
-                let write_report = model_writer.write_batch(&batch.shape_insts).await?;
-                let base_ms = base_start.elapsed().as_millis();
-                drop(permit);
-                println!(
-                    "[batch_stage] batch={} stage=base worker={} wait_ms={} base_write_ms={} missing_neg_candidates={}",
-                    batch.batch_id,
-                    worker_id,
-                    wait_ms,
-                    base_ms,
-                    write_report.missing_neg_carriers.len()
-                );
-                result_sender
-                    .send_async((batch.batch_id, wait_ms, base_ms))
-                    .await?;
+            let (permit, wait_ms) = acquire_with_wait(semaphore).await?;
+            let base_start = Instant::now();
+            let save_report = model_writer
+                .write_base_batch(BaseInstanceBatch {
+                    batch_id: batch.batch_id,
+                    shape_insts: batch.shape_insts.as_ref(),
+                    mesh_aabb_map: &mesh_aabb_map,
+                    replace_exist: false,
+                    write_inst_relate_aabb: false,
+                })
+                .await?;
+            if !save_report.missing_neg_carriers.is_empty() {
+                let mut guard = missing_neg_carriers.lock().unwrap();
+                guard.extend(save_report.missing_neg_carriers.iter().copied());
             }
+            let base_ms = base_start.elapsed().as_millis();
+            drop(permit);
+            println!(
+                "[batch_stage] batch={} stage=base wait_ms={} base_write_ms={} missing_neg_candidates={}",
+                batch.batch_id,
+                wait_ms,
+                base_ms,
+                save_report.missing_neg_carriers.len()
+            );
+            result_sender
+                .send_async((batch.batch_id, wait_ms, base_ms))
+                .await?;
             Ok::<(), anyhow::Error>(())
         }));
     }
@@ -515,16 +517,14 @@ async fn run_base_writer(
     for handle in handles {
         handle.await.map_err(|e| anyhow::anyhow!(e))??;
     }
-    let finish_report = model_writer.finish().await?;
     drop(result_sender);
-    Ok(finish_report)
+    Ok(())
 }
 
 async fn run_mesh_stage(
     receiver: Receiver<PipelineBatch>,
     output_sender: Sender<BatchMeshOutput>,
     mesh_compute_semaphore: Arc<Semaphore>,
-    worker_count: usize,
     db_option: DbOptionExt,
     gen_mesh: bool,
     mesh_aabb_map: Arc<DashMap<String, parry3d::bounding_volume::Aabb>>,
@@ -548,10 +548,7 @@ async fn run_mesh_stage(
     }
 
     let mut handles = Vec::new();
-    let worker_count = worker_count.max(1);
-    println!("[batch_stage] stage=mesh worker_pool={}", worker_count);
-    for worker_id in 0..worker_count {
-        let receiver = receiver.clone();
+    while let Ok(batch) = receiver.recv_async().await {
         let semaphore = mesh_compute_semaphore.clone();
         let deduper = deduper.clone();
         let mesh_aabb_map = mesh_aabb_map.clone();
@@ -559,60 +556,58 @@ async fn run_mesh_stage(
         let output_sender = output_sender.clone();
         let db_option_inner = db_option.inner.clone();
         handles.push(tokio::spawn(async move {
-            while let Ok(batch) = receiver.recv_async().await {
-                let (permit, wait_ms) = acquire_with_wait(semaphore.clone()).await?;
-                let mesh_start = Instant::now();
-                let tasks = crate::fast_model::mesh_generate::extract_mesh_tasks(&batch.shape_insts);
-                let mesh_task_count = tasks.len();
+            let (permit, wait_ms) = acquire_with_wait(semaphore).await?;
+            let mesh_start = Instant::now();
+            let tasks = crate::fast_model::mesh_generate::extract_mesh_tasks(&batch.shape_insts);
+            let mesh_task_count = tasks.len();
 
-                let mut mesh_results = HashMap::new();
-                let mut mesh_cache_hits = 0usize;
-                let mut mesh_new_generated = 0usize;
+            let mut mesh_results = HashMap::new();
+            let mut mesh_cache_hits = 0usize;
+            let mut mesh_new_generated = 0usize;
 
-                if gen_mesh && !tasks.is_empty() {
-                    mesh_results = crate::fast_model::mesh_generate::generate_meshes_for_batch(
-                        &tasks,
-                        &db_option_inner,
-                        &deduper,
-                        &mesh_aabb_map,
-                        &mesh_pts_map,
-                    )
-                    .await;
-                    mesh_cache_hits = mesh_results
-                        .values()
-                        .filter(|mr| mr.meshed && !mr.bad && mr.pts_hashes.is_empty())
-                        .count();
-                    mesh_new_generated = mesh_results.len().saturating_sub(mesh_cache_hits);
-                }
+            if gen_mesh && !tasks.is_empty() {
+                mesh_results = crate::fast_model::mesh_generate::generate_meshes_for_batch(
+                    &tasks,
+                    &db_option_inner,
+                    &deduper,
+                    &mesh_aabb_map,
+                    &mesh_pts_map,
+                )
+                .await;
+                mesh_cache_hits = mesh_results
+                    .values()
+                    .filter(|mr| mr.meshed && !mr.bad && mr.pts_hashes.is_empty())
+                    .count();
+                mesh_new_generated = mesh_results.len().saturating_sub(mesh_cache_hits);
+            }
 
-                let mesh_ms = mesh_start.elapsed().as_millis();
-                drop(permit);
+            let mesh_ms = mesh_start.elapsed().as_millis();
+            drop(permit);
+            println!(
+                "[batch_stage] batch={} stage=mesh wait_ms={} mesh_ms={} mesh_tasks={} mesh_cache_hit={} mesh_new_generated={}",
+                batch.batch_id, wait_ms, mesh_ms, mesh_task_count, mesh_cache_hits, mesh_new_generated
+            );
+
+            let output_send_start = Instant::now();
+            output_sender
+                .send_async(BatchMeshOutput {
+                    batch_id: batch.batch_id,
+                    shape_insts: batch.shape_insts,
+                    mesh_results,
+                    mesh_task_count,
+                    mesh_cache_hits,
+                    mesh_new_generated,
+                    mesh_ms,
+                    mesh_wait_ms: wait_ms,
+                    batch_started_at: batch.batch_started_at,
+                })
+                .await?;
+            let output_send_wait_ms = output_send_start.elapsed().as_millis();
+            if output_send_wait_ms > 0 {
                 println!(
-                    "[batch_stage] batch={} stage=mesh worker={} wait_ms={} mesh_ms={} mesh_tasks={} mesh_cache_hit={} mesh_new_generated={}",
-                    batch.batch_id, worker_id, wait_ms, mesh_ms, mesh_task_count, mesh_cache_hits, mesh_new_generated
+                    "[batch_stage] batch={} stage=mesh_output send_wait_ms={}",
+                    batch.batch_id, output_send_wait_ms
                 );
-
-                let output_send_start = Instant::now();
-                output_sender
-                    .send_async(BatchMeshOutput {
-                        batch_id: batch.batch_id,
-                        shape_insts: batch.shape_insts,
-                        mesh_results,
-                        mesh_task_count,
-                        mesh_cache_hits,
-                        mesh_new_generated,
-                        mesh_ms,
-                        mesh_wait_ms: wait_ms,
-                        batch_started_at: batch.batch_started_at,
-                    })
-                    .await?;
-                let output_send_wait_ms = output_send_start.elapsed().as_millis();
-                if output_send_wait_ms > 0 {
-                    println!(
-                        "[batch_stage] batch={} stage=mesh_output worker={} send_wait_ms={}",
-                        batch.batch_id, worker_id, output_send_wait_ms
-                    );
-                }
             }
             Ok::<(), anyhow::Error>(())
         }));
@@ -625,111 +620,17 @@ async fn run_mesh_stage(
     Ok(())
 }
 
-async fn process_inst_aabb_batch(
-    batch: JoinedBatchOutput,
-    inst_aabb_semaphore: Arc<Semaphore>,
-    mesh_aabb_map: Arc<DashMap<String, parry3d::bounding_volume::Aabb>>,
-    mesh_pts_map: Arc<DashMap<u64, String>>,
-    completion_sender: Sender<BatchCompletion>,
-    skip_inst_relate_aabb: bool,
-    worker_id: usize,
-) -> anyhow::Result<()> {
-    let (aabb_permit, inst_aabb_wait_ms) = acquire_with_wait(inst_aabb_semaphore).await?;
-    let inst_aabb_start = Instant::now();
-    persist_inst_geo_mesh_results(&batch.mesh_results, &mesh_aabb_map, &mesh_pts_map).await?;
-    if skip_inst_relate_aabb {
-        println!(
-            "[batch_stage] batch={} stage=inst_aabb worker={} skipped=inst_relate_aabb env=AIOS_SKIP_INST_RELATE_AABB",
-            batch.batch_id, worker_id
-        );
-    } else {
-        let (aabb_rows_map, inst_relate_aabb_rows, inst_relate_aabb_ids) =
-            build_inst_relate_aabb_rows(&batch.shape_insts, &batch.mesh_results, &mesh_aabb_map)?;
-        save_inst_relate_aabb_rows(
-            &aabb_rows_map,
-            &inst_relate_aabb_rows,
-            &inst_relate_aabb_ids,
-        )
-        .await?;
-    }
-    let inst_aabb_ms = inst_aabb_start.elapsed().as_millis();
-    drop(aabb_permit);
-
-    let total_ms = batch.batch_started_at.elapsed().as_millis();
-    println!(
-        "[batch_perf] batch={} worker={} base_wait_ms={} base_write_ms={} mesh_wait_ms={} mesh_ms={} inst_aabb_wait_ms={} inst_aabb_ms={} total_ms={} mesh_cache_hit={} mesh_new_generated={} mesh_tasks={}",
-        batch.batch_id,
-        worker_id,
-        batch.base_wait_ms,
-        batch.base_write_ms,
-        batch.mesh_wait_ms,
-        batch.mesh_ms,
-        inst_aabb_wait_ms,
-        inst_aabb_ms,
-        total_ms,
-        batch.mesh_cache_hits,
-        batch.mesh_new_generated,
-        batch.mesh_task_count
-    );
-
-    completion_sender
-        .send_async(BatchCompletion {
-            batch_id: batch.batch_id,
-            mesh_task_count: batch.mesh_task_count,
-            mesh_cache_hits: batch.mesh_cache_hits,
-            mesh_new_generated: batch.mesh_new_generated,
-            base_write_ms: batch.base_write_ms,
-            base_wait_ms: batch.base_wait_ms,
-            mesh_ms: batch.mesh_ms,
-            mesh_wait_ms: batch.mesh_wait_ms,
-            inst_aabb_ms,
-            inst_aabb_wait_ms,
-            total_ms,
-        })
-        .await?;
-    Ok(())
-}
-
 async fn run_inst_aabb_writer(
     receiver: Receiver<BatchMeshOutput>,
     base_result_receiver: Receiver<(u64, u128, u128)>,
     completion_sender: Sender<BatchCompletion>,
     inst_aabb_semaphore: Arc<Semaphore>,
-    worker_count: usize,
     mesh_aabb_map: Arc<DashMap<String, parry3d::bounding_volume::Aabb>>,
     mesh_pts_map: Arc<DashMap<u64, String>>,
+    model_writer: Arc<dyn ModelWriteBackend>,
 ) -> anyhow::Result<()> {
     let skip_inst_relate_aabb = std::env::var_os("AIOS_SKIP_INST_RELATE_AABB").is_some();
-    let worker_count = worker_count.max(1);
-    let (joined_sender, joined_receiver) = flume::unbounded::<JoinedBatchOutput>();
     let mut handles = Vec::new();
-    println!(
-        "[batch_stage] stage=inst_aabb worker_pool={} skip_inst_relate_aabb={}",
-        worker_count, skip_inst_relate_aabb
-    );
-    for worker_id in 0..worker_count {
-        let joined_receiver = joined_receiver.clone();
-        let inst_aabb_semaphore = inst_aabb_semaphore.clone();
-        let mesh_aabb_map = mesh_aabb_map.clone();
-        let mesh_pts_map = mesh_pts_map.clone();
-        let completion_sender = completion_sender.clone();
-        handles.push(tokio::spawn(async move {
-            while let Ok(batch) = joined_receiver.recv_async().await {
-                process_inst_aabb_batch(
-                    batch,
-                    inst_aabb_semaphore.clone(),
-                    mesh_aabb_map.clone(),
-                    mesh_pts_map.clone(),
-                    completion_sender.clone(),
-                    skip_inst_relate_aabb,
-                    worker_id,
-                )
-                .await?;
-            }
-            Ok::<(), anyhow::Error>(())
-        }));
-    }
-
     let mut joiner = BatchStageJoiner::default();
     let mut mesh_closed = false;
     let mut base_closed = false;
@@ -741,12 +642,78 @@ async fn run_inst_aabb_writer(
                     Ok(batch) => {
                         let batch_id = batch.batch_id;
                         if let Some(batch) = joiner.push_mesh_output(batch) {
-                            joined_sender.send_async(batch).await?;
+                            let inst_aabb_semaphore = inst_aabb_semaphore.clone();
+                            let mesh_aabb_map = mesh_aabb_map.clone();
+                            let mesh_pts_map = mesh_pts_map.clone();
+                            let completion_sender = completion_sender.clone();
+                            let skip_inst_relate_aabb = skip_inst_relate_aabb;
+                            let model_writer = model_writer.clone();
+                            handles.push(tokio::spawn(async move {
+                                let (aabb_permit, inst_aabb_wait_ms) = acquire_with_wait(inst_aabb_semaphore).await?;
+                                let inst_aabb_start = Instant::now();
+                                model_writer
+                                    .persist_mesh_results(MeshResultBatch {
+                                        batch_id: batch.batch_id,
+                                        mesh_results: &batch.mesh_results,
+                                        mesh_aabb_map: &mesh_aabb_map,
+                                        mesh_pts_map: &mesh_pts_map,
+                                    })
+                                    .await?;
+                                if skip_inst_relate_aabb {
+                                    println!(
+                                        "[batch_stage] batch={} stage=inst_aabb skipped=inst_relate_aabb env=AIOS_SKIP_INST_RELATE_AABB",
+                                        batch.batch_id
+                                    );
+                                } else {
+                                    model_writer
+                                        .write_inst_relate_aabb(InstRelateAabbBatch {
+                                            batch_id: batch.batch_id,
+                                            shape_insts: batch.shape_insts.as_ref(),
+                                            mesh_results: &batch.mesh_results,
+                                            mesh_aabb_map: &mesh_aabb_map,
+                                        })
+                                        .await?;
+                                }
+                                let inst_aabb_ms = inst_aabb_start.elapsed().as_millis();
+                                drop(aabb_permit);
+
+                                let total_ms = batch.batch_started_at.elapsed().as_millis();
+                                println!(
+                                    "[batch_perf] batch={} base_wait_ms={} base_write_ms={} mesh_wait_ms={} mesh_ms={} inst_aabb_wait_ms={} inst_aabb_ms={} total_ms={} mesh_cache_hit={} mesh_new_generated={} mesh_tasks={}",
+                                    batch.batch_id,
+                                    batch.base_wait_ms,
+                                    batch.base_write_ms,
+                                    batch.mesh_wait_ms,
+                                    batch.mesh_ms,
+                                    inst_aabb_wait_ms,
+                                    inst_aabb_ms,
+                                    total_ms,
+                                    batch.mesh_cache_hits,
+                                    batch.mesh_new_generated,
+                                    batch.mesh_task_count
+                                );
+
+                                completion_sender
+                                    .send_async(BatchCompletion {
+                                        batch_id: batch.batch_id,
+                                        mesh_task_count: batch.mesh_task_count,
+                                        mesh_cache_hits: batch.mesh_cache_hits,
+                                        mesh_new_generated: batch.mesh_new_generated,
+                                        base_write_ms: batch.base_write_ms,
+                                        base_wait_ms: batch.base_wait_ms,
+                                        mesh_ms: batch.mesh_ms,
+                                        mesh_wait_ms: batch.mesh_wait_ms,
+                                        inst_aabb_ms,
+                                        inst_aabb_wait_ms,
+                                        total_ms,
+                                    })
+                                    .await?;
+                                Ok::<(), anyhow::Error>(())
+                            }));
                         } else {
-                            let (pending_mesh, pending_base) = joiner.pending_counts();
                             println!(
-                                "[batch_stage] batch={} stage=join waiting=base_result pending_mesh_outputs={} pending_base_metrics={}",
-                                batch_id, pending_mesh, pending_base
+                                "[batch_stage] batch={} stage=join waiting=base_result",
+                                batch_id
                             );
                         }
                     }
@@ -759,12 +726,78 @@ async fn run_inst_aabb_writer(
                 match base_result {
                     Ok((batch_id, base_wait_ms, base_write_ms)) => {
                         if let Some(batch) = joiner.push_base_metrics(batch_id, base_wait_ms, base_write_ms) {
-                            joined_sender.send_async(batch).await?;
+                            let inst_aabb_semaphore = inst_aabb_semaphore.clone();
+                            let mesh_aabb_map = mesh_aabb_map.clone();
+                            let mesh_pts_map = mesh_pts_map.clone();
+                            let completion_sender = completion_sender.clone();
+                            let skip_inst_relate_aabb = skip_inst_relate_aabb;
+                            let model_writer = model_writer.clone();
+                            handles.push(tokio::spawn(async move {
+                                let (aabb_permit, inst_aabb_wait_ms) = acquire_with_wait(inst_aabb_semaphore).await?;
+                                let inst_aabb_start = Instant::now();
+                                model_writer
+                                    .persist_mesh_results(MeshResultBatch {
+                                        batch_id: batch.batch_id,
+                                        mesh_results: &batch.mesh_results,
+                                        mesh_aabb_map: &mesh_aabb_map,
+                                        mesh_pts_map: &mesh_pts_map,
+                                    })
+                                    .await?;
+                                if skip_inst_relate_aabb {
+                                    println!(
+                                        "[batch_stage] batch={} stage=inst_aabb skipped=inst_relate_aabb env=AIOS_SKIP_INST_RELATE_AABB",
+                                        batch.batch_id
+                                    );
+                                } else {
+                                    model_writer
+                                        .write_inst_relate_aabb(InstRelateAabbBatch {
+                                            batch_id: batch.batch_id,
+                                            shape_insts: batch.shape_insts.as_ref(),
+                                            mesh_results: &batch.mesh_results,
+                                            mesh_aabb_map: &mesh_aabb_map,
+                                        })
+                                        .await?;
+                                }
+                                let inst_aabb_ms = inst_aabb_start.elapsed().as_millis();
+                                drop(aabb_permit);
+
+                                let total_ms = batch.batch_started_at.elapsed().as_millis();
+                                println!(
+                                    "[batch_perf] batch={} base_wait_ms={} base_write_ms={} mesh_wait_ms={} mesh_ms={} inst_aabb_wait_ms={} inst_aabb_ms={} total_ms={} mesh_cache_hit={} mesh_new_generated={} mesh_tasks={}",
+                                    batch.batch_id,
+                                    batch.base_wait_ms,
+                                    batch.base_write_ms,
+                                    batch.mesh_wait_ms,
+                                    batch.mesh_ms,
+                                    inst_aabb_wait_ms,
+                                    inst_aabb_ms,
+                                    total_ms,
+                                    batch.mesh_cache_hits,
+                                    batch.mesh_new_generated,
+                                    batch.mesh_task_count
+                                );
+
+                                completion_sender
+                                    .send_async(BatchCompletion {
+                                        batch_id: batch.batch_id,
+                                        mesh_task_count: batch.mesh_task_count,
+                                        mesh_cache_hits: batch.mesh_cache_hits,
+                                        mesh_new_generated: batch.mesh_new_generated,
+                                        base_write_ms: batch.base_write_ms,
+                                        base_wait_ms: batch.base_wait_ms,
+                                        mesh_ms: batch.mesh_ms,
+                                        mesh_wait_ms: batch.mesh_wait_ms,
+                                        inst_aabb_ms,
+                                        inst_aabb_wait_ms,
+                                        total_ms,
+                                    })
+                                    .await?;
+                                Ok::<(), anyhow::Error>(())
+                            }));
                         } else {
-                            let (pending_mesh, pending_base) = joiner.pending_counts();
                             println!(
-                                "[batch_stage] batch={} stage=join waiting=mesh_output pending_mesh_outputs={} pending_base_metrics={}",
-                                batch_id, pending_mesh, pending_base
+                                "[batch_stage] batch={} stage=join waiting=mesh_output",
+                                batch_id
                             );
                         }
                     }
@@ -785,53 +818,10 @@ async fn run_inst_aabb_writer(
         ));
     }
 
-    drop(joined_sender);
     for handle in handles {
         handle.await.map_err(|e| anyhow::anyhow!(e))??;
     }
     drop(completion_sender);
-    Ok(())
-}
-
-async fn persist_inst_geo_mesh_results(
-    mesh_results: &HashMap<u64, MeshResult>,
-    mesh_aabb_map: &DashMap<String, parry3d::bounding_volume::Aabb>,
-    mesh_pts_map: &DashMap<u64, String>,
-) -> anyhow::Result<()> {
-    if use_file_mesh_state() {
-        flush_aabb_cache();
-        return Ok(());
-    }
-
-    if mesh_results.is_empty() {
-        return Ok(());
-    }
-
-    // 先落 aabb / pts 实体，再把 inst_geo 指向这些记录，避免引用到尚不存在的实体。
-    save_pts_to_surreal(mesh_pts_map).await;
-    save_aabb_to_surreal(mesh_aabb_map).await;
-
-    let mut update_sql = String::new();
-    for (geo_hash, mesh_result) in mesh_results {
-        update_sql.push_str(&mesh_result.to_update_sql(&geo_hash.to_string()));
-    }
-
-    if update_sql.is_empty() {
-        return Ok(());
-    }
-
-    aios_core::model_primary_db()
-        .query(&update_sql)
-        .await
-        .map_err(|e| {
-            let preview: String = update_sql.chars().take(500).collect();
-            anyhow::anyhow!(
-                "回写 inst_geo mesh 结果失败: error={}, sql_preview={}",
-                e,
-                preview
-            )
-        })?;
-
     Ok(())
 }
 
@@ -959,18 +949,17 @@ pub async fn gen_all_geos_data(
         db_option.model_writer_mode.as_str()
     );
 
-    // ✅ SurrealDB 写入侧初始化：仅在 use_surrealdb=true 时需要。
-    if db_option.use_surrealdb
-        && !db_option.defer_db_write
-        && db_option.model_writer_mode.writes_to_surreal()
-    {
-        if let Err(e) = aios_core::rs_surreal::inst::init_model_tables().await {
-            eprintln!("[gen_model] ❌ 初始化 inst_relate 表结构失败: {}", e);
-
-            // 严重错误，建议直接中断，否则后续写入必挂
-            return Err(IndexTreeError::Other(e));
-        }
-    }
+    let model_writer = if db_option.model_writer_mode == ModelWriterMode::DrainOnly {
+        None
+    } else {
+        let writer = create_model_writer(db_option).map_err(IndexTreeError::Other)?;
+        let writer_context = ModelWriterContext::from_db_option(db_option);
+        writer
+            .init(&writer_context)
+            .await
+            .map_err(IndexTreeError::Other)?;
+        Some(writer)
+    };
 
     // =========================
     // LOOP/PRIM 输入缓存初始化（按环境变量启用）
@@ -1020,7 +1009,8 @@ pub async fn gen_all_geos_data(
     }
 
     perf.mark("index_tree_generation");
-    let result = process_index_tree_generation(scope, db_option, target_sesno, time).await;
+    let result =
+        process_index_tree_generation(scope, db_option, target_sesno, time, model_writer).await;
     perf.print_summary();
 
     // 输出 cache miss 报告（覆盖写）。
@@ -1078,6 +1068,7 @@ async fn process_index_tree_generation(
     db_option: &DbOptionExt,
     _target_sesno: Option<u32>,
     time: Instant,
+    model_writer: Option<Arc<dyn ModelWriteBackend>>,
 ) -> Result<GenModelResult> {
     let mut perf = crate::perf_timer::PerfTimer::new("index_tree_generation");
     perf.mark("init");
@@ -1124,17 +1115,7 @@ async fn process_index_tree_generation(
         println!(
             "[model-writer:drain-only] 启动压测消费端：生成 batch 真实运行，但跳过 SurrealDB 写入、mesh stage、AABB 回写和 boolean"
         );
-        let drain_writer = create_model_writer(
-            db_option.model_writer_mode,
-            Arc::new(DashMap::new()),
-            Arc::new(std::sync::Mutex::new(HashSet::new())),
-        );
-        println!(
-            "[gen_model] ModelWriter={} writes_to_surreal={}",
-            drain_writer.name(),
-            drain_writer.writes_to_surreal()
-        );
-        let drain_handle = tokio::spawn(run_model_writer_sink(receiver, drain_writer));
+        let drain_handle = tokio::spawn(run_drain_only_sink(receiver));
         println!("⏳ [1/2] 几何体生成 (BRAN/HANG + LOOP/CATE/PRIM)...");
         let _categorized = gen_index_tree_geos_optimized(
             Arc::new(db_option.clone()),
@@ -1153,9 +1134,7 @@ async fn process_index_tree_generation(
         let drain_stats = drain_handle
             .await
             .map_err(|e| anyhow::anyhow!("drain-only sink 任务异常退出: {}", e))?
-            .map_err(IndexTreeError::Other)?
-            .drain_only_stats
-            .unwrap_or_default();
+            .map_err(IndexTreeError::Other)?;
         drain_stats.print_summary();
         println!(
             "✅ [2/2] drain-only 完成, 总用时 {}ms",
@@ -1165,6 +1144,13 @@ async fn process_index_tree_generation(
         perf.end_current();
         return Ok(GenModelResult { success: true });
     }
+
+    let model_writer = model_writer.ok_or_else(|| {
+        IndexTreeError::Other(anyhow::anyhow!(
+            "active model writer backend was not initialized for mode={}",
+            db_option.model_writer_mode.as_str()
+        ))
+    })?;
 
     // Mesh 生成：生产端只产出 inst batch，mesh/持久化在下游并行阶段完成
     let gen_mesh = db_option.inner.gen_mesh;
@@ -1247,22 +1233,6 @@ async fn process_index_tree_generation(
     let mesh_pts_map: Arc<DashMap<u64, String>> = Arc::new(DashMap::new());
     let missing_neg_carriers_for_reconcile: Arc<std::sync::Mutex<HashSet<RefnoEnum>>> =
         Arc::new(std::sync::Mutex::new(HashSet::new()));
-    let base_model_writer = create_model_writer(
-        db_option.model_writer_mode,
-        mesh_aabb_map.clone(),
-        missing_neg_carriers_for_reconcile.clone(),
-    );
-    println!(
-        "[gen_model] ModelWriter={} writes_to_surreal={}",
-        base_model_writer.name(),
-        base_model_writer.writes_to_surreal()
-    );
-    if !base_model_writer.writes_to_surreal() {
-        return Err(IndexTreeError::Other(anyhow::anyhow!(
-            "ModelWriter={} 不支持 SurrealDB 后处理路径；请使用 drain-only 专用路径或实现对应后处理",
-            base_model_writer.name()
-        )));
-    }
     let base_write_semaphore = Arc::new(Semaphore::new(db_option.get_base_write_concurrency()));
     let mesh_compute_semaphore = Arc::new(Semaphore::new(db_option.get_mesh_compute_concurrency()));
     let inst_aabb_semaphore = Arc::new(Semaphore::new(db_option.get_inst_aabb_write_concurrency()));
@@ -1289,14 +1259,14 @@ async fn process_index_tree_generation(
         base_writer_receiver,
         base_result_sender,
         base_write_semaphore.clone(),
-        db_option.get_base_write_concurrency(),
-        base_model_writer,
+        mesh_aabb_map.clone(),
+        missing_neg_carriers_for_reconcile.clone(),
+        model_writer.clone(),
     ));
     let mesh_stage_handle = tokio::spawn(run_mesh_stage(
         mesh_stage_receiver,
         mesh_output_sender,
         mesh_compute_semaphore,
-        db_option.get_mesh_compute_concurrency(),
         db_option.clone(),
         gen_mesh,
         mesh_aabb_map.clone(),
@@ -1307,9 +1277,9 @@ async fn process_index_tree_generation(
         base_result_receiver,
         completion_sender,
         inst_aabb_semaphore,
-        db_option.get_inst_aabb_write_concurrency(),
         mesh_aabb_map.clone(),
         mesh_pts_map.clone(),
+        model_writer.clone(),
     ));
     println!("⏳ [1/5] 几何体生成 (BRAN/HANG + LOOP/CATE/PRIM)...");
     let categorized = gen_index_tree_geos_optimized(
@@ -1333,15 +1303,10 @@ async fn process_index_tree_generation(
         .await
         .map_err(|e| anyhow::anyhow!("batch sink 任务异常退出: {}", e))?
         .map_err(IndexTreeError::Other)?;
-    let base_writer_report = base_writer_handle
+    base_writer_handle
         .await
         .map_err(|e| anyhow::anyhow!("base writer 任务异常退出: {}", e))?
         .map_err(IndexTreeError::Other)?;
-    println!(
-        "[gen_model] ModelWriter finish: writer={} drain_only_stats={}",
-        base_writer_report.writer_name,
-        base_writer_report.drain_only_stats.is_some()
-    );
     mesh_stage_handle
         .await
         .map_err(|e| anyhow::anyhow!("mesh stage 任务异常退出: {}", e))?
@@ -1423,9 +1388,17 @@ async fn process_index_tree_generation(
 
         // 3.5️⃣ barrier 后补建跨阶段缺失的 neg_relate（LOOP 阶段发现负实体但 PRIM 阶段才创建 geo_relate）
         if use_surrealdb {
-            if let Err(e) = reconcile_missing_neg_relate(&all_refnos, &missing_neg_carriers).await {
-                eprintln!("[gen_model] reconcile_missing_neg_relate 失败: {}", e);
-            }
+            let reconciled = model_writer
+                .reconcile_missing_neg(ReconcileRequest {
+                    all_refnos: &all_refnos,
+                    candidate_carriers: &missing_neg_carriers,
+                })
+                .await
+                .map_err(IndexTreeError::Other)?;
+            println!(
+                "[gen_model] reconcile_missing_neg_relate 完成: inserted={}",
+                reconciled
+            );
         }
 
         // 4️⃣ 可选执行布尔运算
@@ -1448,18 +1421,20 @@ async fn process_index_tree_generation(
             // model_cache boolean worker 已移除（foyer-cache-cleanup）
             match db_option.boolean_pipeline_mode {
                 BooleanPipelineMode::DbLegacy => {
-                    if use_surrealdb && !defer_db_write {
-                        if let Err(e) =
-                            run_boolean_worker(Arc::new(db_option.inner.clone()), 100).await
-                        {
-                            eprintln!("[gen_model] IndexTree 布尔运算失败（db_legacy）: {}", e);
-                        }
-                    } else {
-                        println!(
-                            "[gen_model] boolean_pipeline_mode=db_legacy，当前模式不满足执行条件（use_surrealdb={} defer_db_write={}）",
-                            use_surrealdb, defer_db_write
-                        );
-                    }
+                    let report = model_writer
+                        .run_boolean_bridge(BooleanBridgeRequest {
+                            mode: BooleanPipelineMode::DbLegacy,
+                            db_option: Arc::new(db_option.inner.clone()),
+                            bool_tasks: Vec::new(),
+                            use_surrealdb,
+                            defer_db_write,
+                        })
+                        .await
+                        .map_err(IndexTreeError::Other)?;
+                    println!(
+                        "[gen_model] db legacy bool bridge 完成: pipeline={} skipped={}",
+                        report.pipeline, report.skipped
+                    );
                 }
                 BooleanPipelineMode::MemoryTasks => {
                     // 模式组合合法性守卫：MemoryTasks 至少需要一种写入通道
@@ -1497,32 +1472,26 @@ async fn process_index_tree_generation(
                             }
                         }
 
-                        match run_bool_worker_from_tasks(
-                            std::mem::take(&mut bool_tasks),
-                            Arc::new(db_option.inner.clone()),
-                            None,
-                        )
-                        .await
-                        {
-                            Ok(report) => {
-                                println!(
-                                    "[gen_model] memory bool worker 完成: total={} cata={} inst={} success={} failed={} skipped={} defer={}",
-                                    report.total,
-                                    report.cata_cnt,
-                                    report.inst_cnt,
-                                    report.success,
-                                    report.failed,
-                                    report.skipped,
-                                    report.deferred_mode
-                                );
-                            }
-                            Err(e) => {
-                                eprintln!(
-                                    "[gen_model] IndexTree 布尔运算失败（memory_tasks）: {}",
-                                    e
-                                );
-                            }
-                        }
+                        let report = model_writer
+                            .run_boolean_bridge(BooleanBridgeRequest {
+                                mode: BooleanPipelineMode::MemoryTasks,
+                                db_option: Arc::new(db_option.inner.clone()),
+                                bool_tasks: std::mem::take(&mut bool_tasks),
+                                use_surrealdb,
+                                defer_db_write,
+                            })
+                            .await
+                            .map_err(IndexTreeError::Other)?;
+                        println!(
+                            "[gen_model] memory bool worker 完成: total={} cata={} inst={} success={} failed={} skipped={} defer={}",
+                            report.total,
+                            report.cata_cnt,
+                            report.inst_cnt,
+                            report.success,
+                            report.failed,
+                            report.skipped,
+                            report.deferred_mode
+                        );
                     }
                 }
             }
@@ -1747,6 +1716,17 @@ async fn process_index_tree_generation(
             eprintln!("[perf] 保存 CSV 报告失败: {}", e);
         }
     }
+
+    model_writer
+        .finalize(FinalizeRequest {
+            total_batches: insert_report.batch_cnt,
+            completed_batches,
+            mesh_cache_hits: total_mesh_cache_hits,
+            mesh_new_generated: total_mesh_new_generated,
+            missing_neg_candidates: missing_neg_carriers.len(),
+        })
+        .await
+        .map_err(IndexTreeError::Other)?;
 
     Ok(GenModelResult { success: true })
 }

--- a/src/fast_model/gen_model/orchestrator.rs
+++ b/src/fast_model/gen_model/orchestrator.rs
@@ -1109,6 +1109,18 @@ async fn process_index_tree_generation(
     let use_surrealdb = db_option.use_surrealdb;
     let defer_db_write = false;
 
+    // [arch] DrainOnly fast path = baseline mode.
+    //
+    // 由用户拍板（2026-05-11，docs/plans/2026-05-09-model-write-trait-followup/
+    // findings.md §3）：DrainOnly 用途是「跳过所有持久化、仅跑生产端与调度，作为
+    // baseline 对比不同 backend 的 IO 写入耗时」。本分支主动绕过 base_writer /
+    // mesh_stage / inst_aabb_writer 三个并行 stage，只把 trait 的 init+finalize
+    // 路由进来；DrainOnly backend 的中间六个方法在生产路径上**故意不会被走到**，
+    // 详见 `model_writer/drain_only.rs` 顶部 module doc。
+    //
+    // 重构本分支前必须：(1) 把 baseline 用途显式迁移到主管线（DrainOnly backend
+    // 中间方法 NoOp 让主管线 IO 失活）；(2) 跑一次同 dbnum 的 drain-only 模式确认
+    // 总耗时与既有基线一致；(3) 同步更新 drain_only.rs / findings.md。
     if db_option.model_writer_mode == ModelWriterMode::DrainOnly {
         println!(
             "[model-writer:drain-only] 启动压测消费端：生成 batch 真实运行，但跳过 SurrealDB 写入、mesh stage、AABB 回写和 boolean"

--- a/src/fast_model/gen_model/orchestrator.rs
+++ b/src/fast_model/gen_model/orchestrator.rs
@@ -21,9 +21,10 @@ use crate::data_interface::db_meta_manager::db_meta;
 use crate::fast_model::gen_model::boolean_task::{BooleanTask, BooleanTaskAccumulator};
 use crate::fast_model::gen_model::model_writer::{
     BaseInstanceBatch, BooleanBridgeRequest, FinalizeRequest, InstRelateAabbBatch, MeshResultBatch,
-    ModelWriteBackend, ModelWriterContext, ReconcileRequest, create_model_writer,
+    ModelWriterBackend, ModelWriterContext, ReconcileRequest, create_model_writer,
     run_drain_only_sink,
 };
+use crate::fast_model::gen_model::mesh_state::use_file_mesh_state;
 use crate::fast_model::mesh_generate::{MeshResult, query_existing_meshed_inst_geo_ids};
 use crate::options::{BooleanPipelineMode, DbOptionExt, MeshFormat, ModelWriterMode};
 use dashmap::DashMap;
@@ -473,7 +474,7 @@ async fn run_base_writer(
     base_write_semaphore: Arc<Semaphore>,
     mesh_aabb_map: Arc<DashMap<String, parry3d::bounding_volume::Aabb>>,
     missing_neg_carriers: Arc<std::sync::Mutex<HashSet<RefnoEnum>>>,
-    model_writer: Arc<dyn ModelWriteBackend>,
+    model_writer: Arc<dyn ModelWriterBackend>,
 ) -> anyhow::Result<()> {
     let mut handles = Vec::new();
     while let Ok(batch) = receiver.recv_async().await {
@@ -505,7 +506,7 @@ async fn run_base_writer(
                 batch.batch_id,
                 wait_ms,
                 base_ms,
-                save_report.missing_neg_carriers.len()
+                save_report.missing_neg_count
             );
             result_sender
                 .send_async((batch.batch_id, wait_ms, base_ms))
@@ -627,7 +628,7 @@ async fn run_inst_aabb_writer(
     inst_aabb_semaphore: Arc<Semaphore>,
     mesh_aabb_map: Arc<DashMap<String, parry3d::bounding_volume::Aabb>>,
     mesh_pts_map: Arc<DashMap<u64, String>>,
-    model_writer: Arc<dyn ModelWriteBackend>,
+    model_writer: Arc<dyn ModelWriterBackend>,
 ) -> anyhow::Result<()> {
     let skip_inst_relate_aabb = std::env::var_os("AIOS_SKIP_INST_RELATE_AABB").is_some();
     let mut handles = Vec::new();
@@ -657,6 +658,7 @@ async fn run_inst_aabb_writer(
                                         mesh_results: &batch.mesh_results,
                                         mesh_aabb_map: &mesh_aabb_map,
                                         mesh_pts_map: &mesh_pts_map,
+                                        file_mesh_state: use_file_mesh_state(),
                                     })
                                     .await?;
                                 if skip_inst_relate_aabb {
@@ -741,6 +743,7 @@ async fn run_inst_aabb_writer(
                                         mesh_results: &batch.mesh_results,
                                         mesh_aabb_map: &mesh_aabb_map,
                                         mesh_pts_map: &mesh_pts_map,
+                                        file_mesh_state: use_file_mesh_state(),
                                     })
                                     .await?;
                                 if skip_inst_relate_aabb {
@@ -949,17 +952,12 @@ pub async fn gen_all_geos_data(
         db_option.model_writer_mode.as_str()
     );
 
-    let model_writer = if db_option.model_writer_mode == ModelWriterMode::DrainOnly {
-        None
-    } else {
-        let writer = create_model_writer(db_option).map_err(IndexTreeError::Other)?;
-        let writer_context = ModelWriterContext::from_db_option(db_option);
-        writer
-            .init(&writer_context)
-            .await
-            .map_err(IndexTreeError::Other)?;
-        Some(writer)
-    };
+    let model_writer = create_model_writer(db_option).map_err(IndexTreeError::Other)?;
+    let writer_context = ModelWriterContext::from_db_option(db_option);
+    model_writer
+        .init(&writer_context)
+        .await
+        .map_err(IndexTreeError::Other)?;
 
     // =========================
     // LOOP/PRIM 输入缓存初始化（按环境变量启用）
@@ -1068,7 +1066,7 @@ async fn process_index_tree_generation(
     db_option: &DbOptionExt,
     _target_sesno: Option<u32>,
     time: Instant,
-    model_writer: Option<Arc<dyn ModelWriteBackend>>,
+    model_writer: Arc<dyn ModelWriterBackend>,
 ) -> Result<GenModelResult> {
     let mut perf = crate::perf_timer::PerfTimer::new("index_tree_generation");
     perf.mark("init");
@@ -1141,16 +1139,23 @@ async fn process_index_tree_generation(
             full_start.elapsed().as_millis()
         );
         perf.mark("drain_only_complete");
+
+        let total_batches = drain_stats.batches as u64;
+        let completed_batches = drain_stats.batches;
+        model_writer
+            .finalize(FinalizeRequest {
+                total_batches,
+                completed_batches,
+                mesh_cache_hits: 0,
+                mesh_new_generated: 0,
+                missing_neg_candidates: 0,
+            })
+            .await
+            .map_err(IndexTreeError::Other)?;
+
         perf.end_current();
         return Ok(GenModelResult { success: true });
     }
-
-    let model_writer = model_writer.ok_or_else(|| {
-        IndexTreeError::Other(anyhow::anyhow!(
-            "active model writer backend was not initialized for mode={}",
-            db_option.model_writer_mode.as_str()
-        ))
-    })?;
 
     // Mesh 生成：生产端只产出 inst batch，mesh/持久化在下游并行阶段完成
     let gen_mesh = db_option.inner.gen_mesh;
@@ -1426,8 +1431,6 @@ async fn process_index_tree_generation(
                             mode: BooleanPipelineMode::DbLegacy,
                             db_option: Arc::new(db_option.inner.clone()),
                             bool_tasks: Vec::new(),
-                            use_surrealdb,
-                            defer_db_write,
                         })
                         .await
                         .map_err(IndexTreeError::Other)?;
@@ -1477,8 +1480,6 @@ async fn process_index_tree_generation(
                                 mode: BooleanPipelineMode::MemoryTasks,
                                 db_option: Arc::new(db_option.inner.clone()),
                                 bool_tasks: std::mem::take(&mut bool_tasks),
-                                use_surrealdb,
-                                defer_db_write,
                             })
                             .await
                             .map_err(IndexTreeError::Other)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -771,6 +771,45 @@ async fn main() -> anyhow::Result<()> {
                 .num_args(1..),
         )
         .subcommand(
+            Command::new("model-writer")
+                .about("Model writer storage validation utilities")
+                .subcommand(
+                    Command::new("validate-canonical-parquet")
+                        .about("Validate CanonicalRawPlanner + CanonicalParquetWriter with an empty ShapeInstancesData fixture")
+                        .arg(
+                            Arg::new("output")
+                                .long("output")
+                                .short('o')
+                                .help("Output directory for JSONL table files and batch summary")
+                                .required(true)
+                                .value_name("DIR"),
+                        )
+                        .arg(
+                            Arg::new("project-name")
+                                .long("project-name")
+                                .help("Project name partition to write")
+                                .default_value("canonical-validation")
+                                .value_name("NAME"),
+                        )
+                        .arg(
+                            Arg::new("dbnum")
+                                .long("dbnum")
+                                .help("Dbnum partition to write")
+                                .default_value("0")
+                                .value_parser(clap::value_parser!(u32))
+                                .value_name("DBNUM"),
+                        )
+                        .arg(
+                            Arg::new("batch-id")
+                                .long("batch-id")
+                                .help("Batch id to write")
+                                .default_value("1")
+                                .value_parser(clap::value_parser!(u64))
+                                .value_name("ID"),
+                        ),
+                ),
+        )
+        .subcommand(
             Command::new("spatial")
                 .about("SQLite 空间范围查询与回归验证")
                 .subcommand(
@@ -1129,8 +1168,7 @@ async fn main() -> anyhow::Result<()> {
         );
     }
     if let Some(backends) = matches.get_one::<String>("transform-compare-backends") {
-        db_option_ext.transform_compare_backends =
-            parse_transform_compare_backends(Some(backends));
+        db_option_ext.transform_compare_backends = parse_transform_compare_backends(Some(backends));
         let labels = db_option_ext
             .transform_compare_backends
             .iter()
@@ -1426,6 +1464,31 @@ async fn main() -> anyhow::Result<()> {
             .get_many::<u32>("dbnums")
             .map(|values| values.copied().collect());
         return aios_database::init_project::run_init_project_mode(db_option_ext, cli_dbnums).await;
+    }
+
+    if let Some(("model-writer", model_writer_matches)) = matches.subcommand() {
+        if let Some(("validate-canonical-parquet", sub_matches)) = model_writer_matches.subcommand()
+        {
+            let output_dir = sub_matches
+                .get_one::<String>("output")
+                .map(PathBuf::from)
+                .expect("required by clap");
+            let project_name = sub_matches
+                .get_one::<String>("project-name")
+                .map(String::as_str)
+                .unwrap_or("canonical-validation");
+            let dbnum = sub_matches.get_one::<u32>("dbnum").copied().unwrap_or(0);
+            let batch_id = sub_matches.get_one::<u64>("batch-id").copied().unwrap_or(1);
+
+            let report = cli_modes::validate_canonical_parquet_writer_mode(
+                &output_dir,
+                project_name,
+                dbnum,
+                batch_id,
+            )?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            return Ok(());
+        }
     }
 
     // ========== 处理 --gen-all-desi-indextree 参数 ==========
@@ -2602,20 +2665,18 @@ async fn main() -> anyhow::Result<()> {
                 );
             }
 
-            let count =
-                aios_database::pe_transform_refresh::refresh_pe_transform_for_dbnums(
-                    &dbnums,
-                    &db_option_ext,
-                )
-                .await?;
+            let count = aios_database::pe_transform_refresh::refresh_pe_transform_for_dbnums(
+                &dbnums,
+                &db_option_ext,
+            )
+            .await?;
             println!("✅ pe_transform 刷新完成，共处理 {} 个节点", count);
             if !db_option_ext.transform_compare_backends.is_empty() {
-                let stats =
-                    aios_database::pe_transform_store::compare_backends_for_dbnums(
-                        &db_option_ext,
-                        &dbnums,
-                    )
-                    .await?;
+                let stats = aios_database::pe_transform_store::compare_backends_for_dbnums(
+                    &db_option_ext,
+                    &dbnums,
+                )
+                .await?;
                 println!("📊 pe_transform backend 对比结果:");
                 for stat in stats {
                     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1014,6 +1014,31 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    if let Some(("model-writer", model_writer_matches)) = matches.subcommand() {
+        if let Some(("validate-canonical-parquet", sub_matches)) = model_writer_matches.subcommand()
+        {
+            let output_dir = sub_matches
+                .get_one::<String>("output")
+                .map(PathBuf::from)
+                .expect("required by clap");
+            let project_name = sub_matches
+                .get_one::<String>("project-name")
+                .map(String::as_str)
+                .unwrap_or("canonical-validation");
+            let dbnum = sub_matches.get_one::<u32>("dbnum").copied().unwrap_or(0);
+            let batch_id = sub_matches.get_one::<u64>("batch-id").copied().unwrap_or(1);
+
+            let report = cli_modes::validate_canonical_parquet_writer_mode(
+                &output_dir,
+                project_name,
+                dbnum,
+                batch_id,
+            )?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            return Ok(());
+        }
+    }
+
     // 获取配置文件路径
     let config_path = matches
         .get_one::<String>("config")
@@ -1464,31 +1489,6 @@ async fn main() -> anyhow::Result<()> {
             .get_many::<u32>("dbnums")
             .map(|values| values.copied().collect());
         return aios_database::init_project::run_init_project_mode(db_option_ext, cli_dbnums).await;
-    }
-
-    if let Some(("model-writer", model_writer_matches)) = matches.subcommand() {
-        if let Some(("validate-canonical-parquet", sub_matches)) = model_writer_matches.subcommand()
-        {
-            let output_dir = sub_matches
-                .get_one::<String>("output")
-                .map(PathBuf::from)
-                .expect("required by clap");
-            let project_name = sub_matches
-                .get_one::<String>("project-name")
-                .map(String::as_str)
-                .unwrap_or("canonical-validation");
-            let dbnum = sub_matches.get_one::<u32>("dbnum").copied().unwrap_or(0);
-            let batch_id = sub_matches.get_one::<u64>("batch-id").copied().unwrap_or(1);
-
-            let report = cli_modes::validate_canonical_parquet_writer_mode(
-                &output_dir,
-                project_name,
-                dbnum,
-                batch_id,
-            )?;
-            println!("{}", serde_json::to_string_pretty(&report)?);
-            return Ok(());
-        }
     }
 
     // ========== 处理 --gen-all-desi-indextree 参数 ==========

--- a/src/options.rs
+++ b/src/options.rs
@@ -408,6 +408,7 @@ impl DbOptionExt {
     }
 
     pub fn validate_model_writer_features(&self) -> anyhow::Result<()> {
+        // 1) feature flag 守卫：编译期 feature 集不匹配 → 拒绝
         match self.model_writer_mode {
             ModelWriterMode::Surreal
                 if !cfg!(any(
@@ -420,9 +421,18 @@ impl DbOptionExt {
                 )
             }
             // drain-only is a non-persistent throughput sink and does not need a storage feature.
-            ModelWriterMode::DrainOnly => Ok(()),
-            _ => Ok(()),
+            ModelWriterMode::DrainOnly => return Ok(()),
+            _ => {}
         }
+
+        // 2) 运行时配置组合守卫：Surreal backend 必须配 use_surrealdb=true
+        if matches!(self.model_writer_mode, ModelWriterMode::Surreal) && !self.use_surrealdb {
+            anyhow::bail!(
+                "model_writer=surreal 要求 use_surrealdb=true；当前 use_surrealdb=false 是非法组合（早期拒绝以避免空跑 perf init / pre_check）"
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -409,16 +409,18 @@ impl DbOptionExt {
 
     pub fn validate_model_writer_features(&self) -> anyhow::Result<()> {
         match self.model_writer_mode {
-            ModelWriterMode::Surreal if !cfg!(feature = "write-to-surrealdb") => {
+            ModelWriterMode::Surreal
+                if !cfg!(any(
+                    feature = "write-to-surrealdb",
+                    feature = "surreal-save"
+                )) =>
+            {
                 anyhow::bail!(
-                    "model_writer=surreal 需要编译 feature `write-to-surrealdb`；请使用 --features \"review\" 或显式加入 write-to-surrealdb"
+                    "model_writer=surreal 需要编译 feature `surreal-save` 或 `write-to-surrealdb`；请使用 mission cargo check feature 集或 --features \"review\""
                 )
             }
-            ModelWriterMode::DrainOnly if !cfg!(feature = "model-writer-drain") => {
-                anyhow::bail!(
-                    "model_writer=drain-only 需要编译 feature `model-writer-drain`；例如 --features \"review,model-writer-drain\""
-                )
-            }
+            // drain-only is a non-persistent throughput sink and does not need a storage feature.
+            ModelWriterMode::DrainOnly => Ok(()),
             _ => Ok(()),
         }
     }


### PR DESCRIPTION
## Summary

收口 `ModelWriterBackend` trait 的二期审核 — 修复 2 Critical / 5 Warning / 6 Note (详见
`docs/plans/2026-05-09-model-write-trait-followup/findings.md`)，让 trait 真正承担"统一
持久化抽象"职责：生命周期契约不再被绕过，接口日志不再误导，`DrainOnly = baseline` 架构在
代码里上锁。

本 PR 不动 DrainOnly 快速路径的运行时行为 (用户拍板保留作为 backend 写入耗时 baseline)，
只通过 module doc + 函数体 invariant 注释 + orchestrator `[arch]` 注释三处互指把语义锁死。

### Plannotator v2 approved 计划

`C:\Users\dpc\.plannotator\plans\2026-05-11-142958-modelwriterbackend-trait-v2-approved.md`

## Commits (5)

| Commit | 主题 | 解决 |
|---|---|---|
| `b4d93ca0` | fix(model-writer): obey trait lifecycle in run_regen_model | C-A |
| `c8faec3d` | docs(model-writer): pin drain-only baseline architecture invariant | C-B |
| `c63ea11e` | refactor(model-writer): de-hardcode skipped log, tighten record key, doc trait surface | W-A / W-B / W-C / W-D / W-E |
| `9678510c` | chore(model-writer): drop dead feature + enrich verify binary | N-1 / N-2 / N-3 |
| `8bb69632` | docs(plan): sync model-writer-trait followup progress + decisions to HEAD | 计划文档同步 |

## 关键修复点

### Critical

- **C-A `cli_modes::run_regen_model` 漏 `init`**：原代码直接 `create_model_writer + cleanup`，
  Surreal backend 不依赖 init 副作用所以巧合不炸，未来 Parquet/DuckLake 必炸。补 init 调用 +
  注释明确 lifecycle 契约。
- **C-B DrainOnly 快速路径绕过 trait 中间 6 个方法**：用户拍板这是 baseline 模式的必需设计
  (跳过持久化才能对比不同 backend 的写入耗时)。本 PR 不改运行时行为，只通过
  `drain_only.rs` module doc + 6 个函数体 `architectural-invariant` 注释 +
  `orchestrator.rs` `[arch]` 块注释 + `findings.md §3` 决策行四处互指锁定语义，避免后人误以
  为是 bug 去重构。

### Warning

- **W-A** `BooleanBridgeReport::skipped` 日志标签去硬编码 `[model-writer:surreal]` → `[model-writer:{pipeline}]`。
- **W-B** `SurrealRecordKey::new` 删 `starts_with` 分支 + 白名单去 `:`，统一输出 `table:⟨raw_key⟩`，避免两种格式不一致。
- **W-C** `WriteBaseReport` 删 `#[non_exhaustive]` (同 crate 内无效)，给 `missing_neg_carriers` 加 doc 说明 P5 拆分计划。
- **W-D** `parquet.rs` 顶部加 module doc 明确"不是 ModelWriterBackend impl"，`mod.rs` `pub use` 加位置标注。
- **W-E** `BooleanBridgeRequest::db_option` 加 `TODO(P5)` 标记。

### Note

- **N-1** `Cargo.toml` 删死 feature `model-writer-drain`。
- **N-2** `verify_model_writer_trait` binary 真正消费 `RecordingBackend` 的注入字段
  (`injected_reconcile_inserted` / `injected_missing_neg`)，验证 backend 返回值与注入精确匹配。
- **N-3** verify binary 加二次 init 安全 + cleanup-without-init 安全 + 反例硬检查 (snapshot
  不能含未预期方法名)；exit code 拓展为 0-5。
- **N-4** `name() -> const NAME` 标 Skipped — dyn vtable 不接 const，无法替代 method。
- N-5/N-6 不在本 PR 范围，留 P5 backlog。

## Files changed

- `src/cli_modes.rs` (C-A)
- `src/fast_model/gen_model/model_writer/mod.rs` (W-A / W-C / W-D / W-E)
- `src/fast_model/gen_model/model_writer/surreal.rs` (W-B)
- `src/fast_model/gen_model/model_writer/drain_only.rs` (C-B)
- `src/fast_model/gen_model/model_writer/parquet.rs` (W-D)
- `src/fast_model/gen_model/orchestrator.rs` (C-B)
- `src/bin/verify_model_writer_trait.rs` (N-2 / N-3)
- `Cargo.toml` (N-1)
- `docs/plans/2026-05-09-model-write-trait-followup/{findings,task_plan,progress}.md` (文档同步)

## Test plan

- [ ] CI 跑 `cargo check --bin plant_db_cli --features review` 通过
- [ ] CI / 本地跑 `pwsh -NoProfile -File docs/plans/2026-05-09-model-write-trait-followup/verify-mock.ps1`
      exit code = 0 (新 verify binary 9 步序列 + 注入断言全过)
- [ ] 选 1 个最小 dbnum 跑一次 `gen-model --model_writer_mode=surreal`，对比 SurrealDB 写前/后
      行数 + 抽样确认 `aabb:⟨...⟩` / `vec3:⟨...⟩` record id 形态统一
- [ ] 同 dbnum 跑一次 `gen-model --model_writer_mode=drain-only`，确认 stats summary 与既有
      baseline 一致 (确认 W-B / C-B 改动不影响 DrainOnly 行为)
- [ ] 启动 `web_server` 跑一次 `/api/health` smoke

## 已知限制

- 本 PR 不动 DrainOnly 快速路径，DrainOnly backend 的 6 个中间方法在生产路径上故意不会被走到
  (仅 mock/verify 走)。语义锁在文档里。
- `WriteBaseReport.missing_neg_carriers` / `BooleanBridgeRequest::db_option` / `parquet.rs`
  入 trait 工厂 — 三项 P5 backlog，本 PR 仅加标记和 TODO。

## 关联

- 上一轮 PR base: `feat/model-persistence-trait` 自 `f0aedb6` 起，2026-05-09 P4 工作未推
- 二期审核报告：`docs/plans/2026-05-09-model-write-trait-followup/findings.md` §2 + §3 + §4
- Plannotator v2 plan: 见 Summary 顶部存档路径

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors the `gen_model` orchestration to route all persistence/mesh/boolean stages through the new `ModelWriterBackend` trait and adjusts SurrealDB record-id construction, which can impact data writes and runtime behavior. Safeguards are added via explicit lifecycle calls, stricter key validation, and a dedicated verification binary, but regressions would surface in model generation/DB persistence paths.
> 
> **Overview**
> Refactors the model-generation write pipeline to **fully use `ModelWriterBackend`**: `gen_model` now always calls `init`/`cleanup`/per-stage write methods/`finalize` via the trait, and `run_regen_model` is fixed to no longer skip backend `init` before `cleanup`.
> 
> Formally **locks in `DrainOnly` as a baseline fast-path** (still bypassing the six middle trait methods) with explicit architecture docs/invariant comments, while moving the previous monolithic `model_writer.rs` into a modular backend layout (`surreal`, `drain_only`, `mock`) and adding a new `canonical_records` planner plus a JSONL-based canonical sink scaffold.
> 
> Hardens and clarifies behavior: `BooleanBridgeReport::skipped` logging is de-hardcoded to the actual pipeline, SurrealDB mesh `aabb`/`vec3` record IDs are validated/sanitized and normalized to a single `table:⟨key⟩` form, model-writer feature validation is tightened, and a new feature-gated `verify_model_writer_trait` binary + `model-writer validate-canonical-parquet` CLI are added for contract/fixture validation. Dependency lock entries are updated to use the intended git sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80ed27145257e08bf5588aecfeae5eab637c7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->