### PR TITLE
docs(model-writer-storage): Phase 1 mission docs (canonical raw + parquet/ducklake roadmap)

### DIFF
--- a/docs/development/model-writer-storage/00-mission-overview.md
+++ b/docs/development/model-writer-storage/00-mission-overview.md
@@ -1,0 +1,58 @@
+# ModelWriter Storage Mission Overview
+
+## Mission
+
+Design a docs-first path for moving `ModelWriter` from a SurrealDB-only writer toward a multi-backend storage architecture.
+
+The first implementation target is a canonical write contract shared by:
+
+- existing SurrealDB writeback
+- future DuckLake writer
+- future Parquet writer
+- CLI + SQL validation tooling
+
+## Scope
+
+Phase 1 covers raw model generation persistence:
+
+- `inst_info`
+- `inst_relate`
+- `inst_geo`
+- `geo_relate`
+- `tubi_info`
+- `tubi_relate`
+- `neg_relate`
+- `ngmr_relate`
+- `aabb`
+- `trans`
+- `vec3`
+- `inst_relate_aabb`
+- `refno_assoc_index`
+
+Phase 2 covers boolean result tables:
+
+- `inst_relate_bool`
+- `inst_relate_cata_bool`
+
+## Non-goals
+
+- Do not replace the current SurrealDB backend in Phase 1.
+- Do not require a completed DuckLake writer for Phase 1 raw acceptance.
+- Do not use temp-Parquet-plus-SQL as the final DuckLake architecture.
+- Do not use Rust tests for validation.
+- Do not change Cargo source configuration for SurrealDB; it must remain `github.com/happyrust/surrealdb`.
+
+## Target outcome
+
+The codebase should gain a storage boundary where model generation emits canonical records once, and each backend persists those records using backend-specific mechanics while preserving the current SurrealDB contract.
+
+```mermaid
+flowchart LR
+  G[Model generation] --> C[Canonical write batches]
+  C --> S[SurrealDB writer]
+  C --> D[DuckLake writer]
+  C --> P[Parquet writer]
+  S --> V[CLI + SQL validation]
+  D --> V
+  P --> V
+```

--- a/docs/development/model-writer-storage/01-current-surreal-write-contract.md
+++ b/docs/development/model-writer-storage/01-current-surreal-write-contract.md
@@ -1,0 +1,41 @@
+# Current SurrealDB Write Contract
+
+## Current behavior
+
+`ModelWriterBackend` currently selects `SurrealModelWriterBackend` for normal generation. That backend delegates to existing generation helpers for cleanup, base instance writes, mesh result persistence, AABB relation writes, negative relation reconciliation, and boolean bridge execution.
+
+SurrealDB remains the source-of-truth contract for Phase 1. New storage backends must match its observable rows and references for raw model data before adding backend-specific optimizations.
+
+## Contract principles
+
+- Record identity must remain stable across backends.
+- Relation direction must preserve SurrealDB meaning: `in` is the source record and `out` is the target record.
+- Shared payload tables (`aabb`, `trans`, `vec3`) are canonical value tables referenced by relation/projection tables.
+- Boolean result tables are excluded from Phase 1 and handled in Phase 2.
+- Validation is CLI + SQL only.
+
+## Parity matrix
+
+| Surreal object | Role | Canonical raw table | Canonical projection | Phase |
+|---|---|---:|---:|---|
+| `inst_info` | Instance payload keyed by catalog/hash identity | `raw_inst_info` | `projection_instances` | Phase 1 |
+| `inst_relate` | `pe` to `inst_info` relation; primary refno-to-instance bridge | `raw_inst_relate` | `projection_instances` | Phase 1 |
+| `inst_geo` | Geometry payload keyed by geometry hash/id, including mesh status and payload references | `raw_inst_geo` | `projection_geometry` | Phase 1 |
+| `geo_relate` | `inst_info` to `inst_geo` relation with geometry refno, type, transform, visibility | `raw_geo_relate` | `projection_instance_geometry` | Phase 1 |
+| `tubi_info` | Tubing segment payload | `raw_tubi_info` | `projection_tubing` | Phase 1 |
+| `tubi_relate` | Instance/catalog to tubing payload relation | `raw_tubi_relate` | `projection_tubing` | Phase 1 |
+| `neg_relate` | Negative geometry dependency relation | `raw_neg_relate` | `projection_dependencies` | Phase 1 |
+| `ngmr_relate` | Non-geometry/negative mesh dependency relation | `raw_ngmr_relate` | `projection_dependencies` | Phase 1 |
+| `aabb` | Shared AABB value table | `raw_aabb` | `projection_bounds` | Phase 1 |
+| `trans` | Shared transform value table | `raw_trans` | `projection_transforms` | Phase 1 |
+| `vec3` | Shared point/vector payload table | `raw_vec3` | `projection_mesh_payloads` | Phase 1 |
+| `inst_relate_aabb` | Raw instance-to-AABB relation for original geometry bounds | `raw_inst_relate_aabb` | `projection_bounds` | Phase 1 |
+| `refno_assoc_index` | Regeneration delete/index acceleration metadata | `raw_refno_assoc_index` | `projection_regen_index` | Phase 1 |
+| `inst_relate_bool` | Instance-level boolean result status and mesh pointer | `raw_inst_relate_bool` | `projection_boolean_results` | Phase 2 |
+| `inst_relate_cata_bool` | Catalog-level boolean result relation | `raw_inst_relate_cata_bool` | `projection_boolean_results` | Phase 2 |
+
+## Backend parity requirements
+
+1. A Phase 1 backend is complete only when every Phase 1 row class above is either written directly or intentionally represented by an equivalent canonical projection; `inst_relate_bool` and `inst_relate_cata_bool` remain Phase 2 and are not required for acceptance.
+2. `inst_relate_bool` and `inst_relate_cata_bool` must not gate Phase 1 acceptance.
+3. Backend validation compares SurrealDB and candidate backend output through CLI-generated data and SQL queries, not Rust tests.

--- a/docs/development/model-writer-storage/02-canonical-schema.md
+++ b/docs/development/model-writer-storage/02-canonical-schema.md
@@ -1,0 +1,52 @@
+# Canonical Schema
+
+## Schema layers
+
+The storage architecture uses two schema layers:
+
+- Raw tables: loss-minimized records corresponding to current SurrealDB objects.
+- Projection tables: query-oriented tables for validation, export, and future runtime reads.
+
+The DuckLake namespace for the canonical schema is `ducklake-canonical`.
+
+## Raw schema tables
+
+| Table | Key columns | Required payload | Notes |
+|---|---|---|---|
+| `raw_inst_info` | `inst_id`, `dbnum` | serialized instance info, catalog hash, refno metadata | Mirrors `inst_info`. |
+| `raw_inst_relate` | `refno`, `dbnum` | `pe_id`, `inst_id`, relation id | Mirrors `inst_relate`. |
+| `raw_inst_geo` | `geo_hash` | geometry params, mesh flags, AABB id, point/vector refs | Mirrors `inst_geo`. |
+| `raw_geo_relate` | `inst_id`, `geo_hash`, `geom_refno` | `geo_type`, `trans_id`, `visible`, relation id | Mirrors `geo_relate`. |
+| `raw_tubi_info` | `tubi_id` | tubing segment payload | Mirrors `tubi_info`. |
+| `raw_tubi_relate` | `inst_id`, `tubi_id` | relation id, source refno/dbnum | Mirrors `tubi_relate`. |
+| `raw_neg_relate` | `carrier_refno`, `target_refno` | relation id, dependency type | Mirrors `neg_relate`. |
+| `raw_ngmr_relate` | `carrier_refno`, `target_refno` | relation id, dependency type | Mirrors `ngmr_relate`. |
+| `raw_aabb` | `aabb_id` | min/max bounds payload | Mirrors `aabb`. |
+| `raw_trans` | `trans_id` | transform matrix payload | Mirrors `trans`. |
+| `raw_vec3` | `vec3_id` | point/vector array payload | Mirrors `vec3`. |
+| `raw_inst_relate_aabb` | `refno` | `aabb_id`, source marker | Mirrors `inst_relate_aabb`. |
+| `raw_refno_assoc_index` | `refno` | associated record ids grouped by table | Mirrors `refno_assoc_index`; retained for delete parity even where runtime use is disabled. |
+
+## Projection schema tables
+
+| Table | Grain | Source raw tables | Purpose |
+|---|---|---|---|
+| `projection_instances` | one row per `dbnum/refno` | `raw_inst_relate`, `raw_inst_info` | Fast instance existence and refno parity checks. |
+| `projection_geometry` | one row per `geo_hash` | `raw_inst_geo`, `raw_aabb`, `raw_vec3` | Geometry payload and mesh status checks. |
+| `projection_instance_geometry` | one row per instance-geometry edge | `raw_geo_relate`, `raw_inst_relate`, `raw_inst_geo`, `raw_trans` | Validate `geo_relate` cardinality and transform linkage. |
+| `projection_tubing` | one row per tubing segment relation | `raw_tubi_relate`, `raw_tubi_info` | Tubing parity and export reads. |
+| `projection_dependencies` | one row per dependency edge | `raw_neg_relate`, `raw_ngmr_relate` | Negative/dependency reconciliation checks. |
+| `projection_bounds` | one row per refno bounds result | `raw_inst_relate_aabb`, `raw_aabb` | Room/spatial validation without Surreal-specific record ids. |
+| `projection_transforms` | one row per transform id | `raw_trans` | Transform de-duplication and SQL comparison. |
+| `projection_mesh_payloads` | one row per vector payload id | `raw_vec3` | Mesh payload availability checks. |
+| `projection_regen_index` | one row per indexed refno | `raw_refno_assoc_index` | Cleanup/delete parity checks. |
+
+## Phase 2 schema placeholder
+
+Boolean outputs are modeled later as Phase 2 tables:
+
+- `raw_inst_relate_bool`
+- `raw_inst_relate_cata_bool`
+- `projection_boolean_results`
+
+They must not be required for Phase 1 acceptance.

--- a/docs/development/model-writer-storage/03-writer-architecture.md
+++ b/docs/development/model-writer-storage/03-writer-architecture.md
@@ -1,0 +1,58 @@
+# Writer Architecture
+
+## Current boundary
+
+The current `ModelWriterBackend` trait already separates orchestration from persistence:
+
+- `init`
+- `cleanup`
+- `write_base_batch`
+- `persist_mesh_results`
+- `write_inst_relate_aabb`
+- `reconcile_missing_neg`
+- `run_boolean_bridge`
+- `finalize`
+
+Phase 1 should keep this orchestration boundary and add a canonical record boundary beneath it.
+
+## Proposed layers
+
+```mermaid
+flowchart TB
+  O[Generation orchestrator] --> T[ModelWriterBackend trait]
+  T --> A[Canonical batch adapter]
+  A --> R[Raw canonical records]
+  R --> S[SurrealDB sink]
+  R --> D[DuckLake sink]
+  R --> P[Parquet sink]
+```
+
+## Responsibilities
+
+| Layer | Responsibility | Not responsible for |
+|---|---|---|
+| Orchestrator | Batch order, generation lifecycle, option selection | Backend row layout |
+| `ModelWriterBackend` | Storage lifecycle and error boundary | SQL dialect details for every backend |
+| Canonical batch adapter | Convert in-memory generation structures into raw canonical records | Persisting records |
+| Backend sink | Durable writes, backend transactions, projection refresh | Changing generation semantics |
+| Validation CLI | Compare row counts, ids, and joins through SQL | Rust unit/integration tests |
+
+## Backend selection
+
+Phase 1 should support explicit backend selection while preserving current default behavior:
+
+- default: SurrealDB writer
+- future: DuckLake writer
+- future: Parquet writer
+- optional compare mode: write SurrealDB plus candidate backend, then compare via CLI + SQL
+- Phase 1 canonical acceptance does not require a finished DuckLake writer; it only requires the raw canonical boundary and validation surface.
+
+## Error handling
+
+- Backend writes must fail fast for missing required raw records.
+- Partial backend failures must include batch id and table/projection name.
+- Compare mode should report mismatches without silently falling back to SurrealDB-only success.
+
+## Boolean boundary
+
+`run_boolean_bridge` remains Phase 2. The Phase 1 canonical writer should not require `inst_relate_bool` or `inst_relate_cata_bool` to validate raw model persistence.

--- a/docs/development/model-writer-storage/04-ducklake-writer.md
+++ b/docs/development/model-writer-storage/04-ducklake-writer.md
@@ -1,0 +1,42 @@
+# DuckLake Writer
+
+## Direction
+
+The future DuckLake implementation should target the Rust DuckDB binding as the final architecture. It should not use temp-Parquet-plus-SQL as the final write path.
+
+Temporary Parquet registration may be useful for investigation, but the mission architecture should converge on a Rust-owned DuckDB/DuckLake writer that creates and mutates canonical tables directly.
+
+## Target design
+
+- Open DuckDB through the Rust DuckDB binding.
+- Attach/load DuckLake metadata for the configured project.
+- Create the `ducklake-canonical` schema if missing.
+- Write raw canonical tables in batch transactions.
+- Refresh projection tables with SQL after raw writes.
+- Expose CLI + SQL validation queries for parity checks.
+
+## Write flow
+
+```mermaid
+sequenceDiagram
+  participant MW as ModelWriter
+  participant CA as Canonical adapter
+  participant DW as DuckLake writer
+  participant DB as DuckDB/DuckLake
+  MW->>CA: generation batch
+  CA->>DW: raw canonical records
+  DW->>DB: transaction insert/upsert raw tables
+  DW->>DB: refresh projections
+  DW-->>MW: batch summary
+```
+
+## Table strategy
+
+- Raw tables are append/upsert targets keyed by stable ids.
+- Projection tables are SQL-derived and may be rebuilt for a dbnum/refno slice.
+- Partitioning should start with `project_name` and `dbnum` where supported.
+- Id columns should use plain scalar values, not SurrealDB record-id syntax.
+
+## Acceptance
+
+DuckLake Phase 1 is a later milestone. Phase 1 raw acceptance for this mission does not require DuckLake implementation completion; it only requires the canonical raw boundary, docs, and validation surfaces to remain consistent.

--- a/docs/development/model-writer-storage/05-parquet-writer.md
+++ b/docs/development/model-writer-storage/05-parquet-writer.md
@@ -1,0 +1,41 @@
+# Parquet Writer
+
+## Role
+
+The Parquet writer is a file-oriented implementation of the canonical raw/projection contract. It is useful for export, offline inspection, and SQL validation through DuckDB or other Parquet-capable tools.
+
+Parquet is not the final DuckLake architecture. DuckLake should use the Rust DuckDB binding directly for durable table writes.
+
+## Layout
+
+Recommended layout:
+
+```text
+output/<project>/model_writer_storage/
+  raw/<table>/project_name=<project>/dbnum=<dbnum>/*.parquet
+  projection/<table>/project_name=<project>/dbnum=<dbnum>/*.parquet
+```
+
+Tables should use the canonical names from `02-canonical-schema.md`.
+
+## Write behavior
+
+- Write raw canonical records as typed Parquet rows.
+- Keep stable scalar ids for `refno`, `inst_id`, `geo_hash`, `aabb_id`, `trans_id`, and `vec3_id`.
+- Avoid embedding SurrealDB record-id syntax as the only identifier.
+- Emit projection Parquet files from the same canonical records or from SQL over raw files.
+
+## Validation
+
+Parquet validation is CLI + SQL:
+
+1. Generate SurrealDB baseline data.
+2. Generate Parquet data for the same dbnum/refno scope.
+3. Query Parquet with SQL.
+4. Compare counts, key sets, relation edges, and projection joins against SurrealDB exports.
+
+## Phase boundary
+
+Phase 1 Parquet excludes `inst_relate_bool` and `inst_relate_cata_bool`. Those boolean result tables are Phase 2.
+
+The first implementation scaffold exposes `CanonicalParquetWriter` under `model_writer` without routing production writes to it by default. To avoid pulling the heavy optional Parquet/Polars stack into the current SurrealDB path before CLI parity checks exist, the scaffold writes canonical raw table JSON Lines files plus a row-count summary under the target Parquet layout boundary. Typed `.parquet` materialization remains the next Parquet worker step.

--- a/docs/development/model-writer-storage/06-orchestrator-integration.md
+++ b/docs/development/model-writer-storage/06-orchestrator-integration.md
@@ -1,0 +1,44 @@
+# Orchestrator Integration
+
+## Integration points
+
+The generation orchestrator should continue to depend on `ModelWriterBackend`, not individual storage engines.
+
+Required integration points:
+
+- writer construction from options
+- `ModelWriterContext` propagation
+- base instance batch writes
+- mesh result persistence
+- `inst_relate_aabb` writes
+- negative relation reconciliation
+- finalization summary
+
+## Option model
+
+Backend selection should remain explicit and conservative:
+
+- `surreal`: current default
+- `ducklake`: future canonical DuckLake writer
+- `parquet`: future canonical Parquet writer
+- `compare`: optional dual-write validation mode
+
+The SurrealDB dependency source in Cargo files must remain `github.com/happyrust/surrealdb`.
+
+## Canonical adapter placement
+
+The canonical adapter should live below orchestration and above concrete sinks. This lets `SurrealModelWriterBackend` remain the compatibility implementation while new writers consume the same canonical records.
+
+## Finalization
+
+`finalize` should report:
+
+- backend name
+- batch counts
+- raw rows written by table
+- projection rows refreshed by table
+- validation hint paths or SQL files when applicable
+
+## Compatibility
+
+Existing SurrealDB behavior is the compatibility baseline. Any new backend must prove parity through CLI + SQL before it can be used as a primary writer.

--- a/docs/development/model-writer-storage/07-validation-plan.md
+++ b/docs/development/model-writer-storage/07-validation-plan.md
@@ -1,0 +1,87 @@
+# Validation Plan
+
+## Rule
+
+Validation is CLI + SQL only. Do not use Rust tests for this mission.
+
+## Validation levels
+
+### 1. Static checks
+
+- Confirm docs and implementation references include required Phase 1 table names.
+- Confirm Cargo files do not reference `gitee.com/happydpc/surrealdb`.
+- Confirm Cargo files keep SurrealDB source on `github.com/happyrust/surrealdb`.
+
+### 2. Generation checks
+
+Use the existing CLI flow for `aios-database` with JSON/config inputs. Generate the same dbnum/refno scope for SurrealDB and the candidate backend.
+
+Expected evidence:
+
+- command line used
+- dbnum/refno scope
+- rows written by canonical raw table
+- rows written/refreshed by projection table
+- elapsed time
+
+### 2a. Canonical raw writer smoke check
+
+Use the non-production CLI validation entry to exercise `CanonicalRawPlanner` and
+the canonical Parquet writer scaffold without full model generation and without
+SurrealDB writes:
+
+```powershell
+cargo run --bin aios-database -- model-writer validate-canonical-parquet --output output/model-writer-validation --project-name canonical-validation --dbnum 0 --batch-id 1
+```
+
+The command builds an empty/default `ShapeInstancesData`, writes canonical raw
+table JSONL fallback files, and prints a JSON report containing:
+
+- `summary_path`
+- `raw_root`
+- `total_rows`
+- per-table `rows` and `path`
+
+For the empty fixture, all row counts are expected to be `0`; the validation
+still confirms the table file layout and summary JSON structure.
+
+### 3. SQL parity checks
+
+Run SQL comparisons for:
+
+- row counts by table
+- missing keys in either backend
+- `inst_relate` refno-to-instance edges
+- `geo_relate` instance-to-geometry edges
+- `tubi_relate` tubing edges
+- `neg_relate` and `ngmr_relate` dependency edges
+- `inst_relate_aabb` bounds linkage
+- orphan checks for `aabb`, `trans`, and `vec3`
+- `refno_assoc_index` delete/index metadata coverage
+
+## Acceptance criteria
+
+Phase 1 passes when CLI + SQL evidence shows parity for every Phase 1 object and documents any intentional, reviewed projection-only representation.
+
+Phase 1 does not require parity for:
+
+- `inst_relate_bool`
+- `inst_relate_cata_bool`
+
+Those are Phase 2.
+
+## Example SQL checks
+
+```sql
+-- Candidate backend missing instance relations present in SurrealDB export.
+SELECT refno
+FROM surreal_inst_relate
+EXCEPT
+SELECT refno
+FROM candidate_raw_inst_relate;
+
+-- Geometry relation cardinality by instance.
+SELECT inst_id, COUNT(*) AS geo_edges
+FROM candidate_raw_geo_relate
+GROUP BY inst_id;
+```

--- a/docs/development/model-writer-storage/08-phase-roadmap.md
+++ b/docs/development/model-writer-storage/08-phase-roadmap.md
@@ -1,0 +1,54 @@
+# Phase Roadmap
+
+## Worker boundaries
+
+| Worker area | Owns | Does not own |
+|---|---|---|
+| Contract worker | Canonical raw/projection schema, parity matrix, table naming | Backend-specific IO tuning |
+| Surreal compatibility worker | Current write contract extraction and Surreal parity exports | DuckLake/Parquet primary implementation |
+| Writer trait worker | `ModelWriterBackend` extension points and canonical adapter boundary | Changing generation semantics |
+| DuckLake worker | Rust DuckDB binding writer, `ducklake-canonical` schema, SQL projections | Temp-Parquet-plus-SQL as final architecture |
+| Parquet worker | Canonical Parquet layout and file SQL validation | DuckLake metadata ownership |
+| Orchestrator worker | Backend selection, batch lifecycle, compare mode integration | Backend table internals |
+| Validation worker | CLI + SQL scripts, parity reports, Cargo source checks | Rust tests |
+
+## Phase 0: Docs-first contract
+
+- Create mission docs.
+- Freeze Phase 1 vs Phase 2 table boundaries.
+- Confirm `inst_relate_bool` and `inst_relate_cata_bool` are Phase 2.
+
+## Phase 1: Canonical raw writer boundary
+
+- Add canonical record structs for all Phase 1 objects.
+- Adapt existing generation batches into canonical raw records.
+- Preserve current SurrealDB writer behavior.
+- Add row-count summaries by canonical table.
+
+## Phase 2: Candidate backend writers
+
+- Implement Parquet writer against canonical raw/projection schema.
+- Implement DuckLake writer through Rust DuckDB binding.
+- Create `ducklake-canonical` schema and projection refresh SQL.
+- Keep DuckLake final architecture independent of temp-Parquet-plus-SQL.
+
+## Phase 3: Orchestrator and compare mode
+
+- Add explicit backend selection.
+- Add optional dual-write/compare path.
+- Fail fast on write errors.
+- Report table-level parity summaries.
+
+## Phase 4: CLI + SQL validation
+
+- Add CLI commands or modes for backend validation.
+- Add SQL checks for every Phase 1 object.
+- Confirm Cargo files do not contain `gitee.com/happydpc/surrealdb`.
+- Confirm SurrealDB source remains `github.com/happyrust/surrealdb`.
+
+## Phase 5: Boolean result storage
+
+- Add canonical records for `inst_relate_bool`.
+- Add canonical records for `inst_relate_cata_bool`.
+- Extend projections with `projection_boolean_results`.
+- Validate through CLI + SQL only.


### PR DESCRIPTION
## Summary

Adds Phase 1 mission documentation for the multi-backend ModelWriter storage architecture. **Docs-only PR**, independent of the trait abstraction PR #11.

## Scope

9 documents under \docs/development/model-writer-storage/\:

- **00-mission-overview**: scope, Phase 1 vs Phase 2 boundary, target outcome
- **01-current-surreal-write-contract**: existing Surreal write contract baseline (compatibility reference)
- **02-canonical-schema**: canonical raw record schema for 13 Phase 1 tables
- **03-writer-architecture**: \ModelWriterBackend\ trait + canonical adapter layering
- **04-ducklake-writer**: target design via Rust DuckDB binding (not temp-Parquet)
- **05-parquet-writer**: file-oriented sink for export + SQL validation
- **06-orchestrator-integration**: backend selection, compare mode, finalization
- **07-validation-plan**: CLI + SQL validation rule, no Rust tests
- **08-phase-roadmap**: Phase 0..5 worker boundaries

## Phase boundaries

| Phase | Coverage | Status |
|---|---|---|
| Phase 0 | Docs-first contract | this PR |
| Phase 1 | Canonical raw writer boundary | tracked via worktree feat/model-persistence-trait (PR #11) |
| Phase 2 | Parquet + DuckLake writers | tracked via v3 plan Phase B + D |
| Phase 3 | Orchestrator backend selection + compare mode | tracked via v3 plan Phase C |
| Phase 4 | CLI + SQL validation | tracked via v3 plan Phase E |
| Phase 5 | Boolean result storage | v4+ |

## Companion

v3 plan: \docs/plans/2026-05-09-model-write-trait-followup/v3-plan.md\ on PR #11.

## Test plan

- [x] All 9 files are Markdown-only, no executable changes
- [x] No references to deprecated Cargo sources (\gitee.com/happydpc/surrealdb\)
- [x] Mermaid diagrams render in GitHub preview
- [ ] Reviewer to confirm Phase 1/2 boundary decisions match team's mental model

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds guidance and contracts but does not modify runtime behavior; risk is limited to potential future implementation misinterpretation.
> 
> **Overview**
> Defines a docs-first Phase 1 contract for evolving `ModelWriter` from SurrealDB-only writes to a **canonical raw/projection schema** that future DuckLake and Parquet backends can share, while keeping SurrealDB as the Phase 1 compatibility baseline.
> 
> Adds a parity matrix, canonical table naming/keying for Phase 1 raw persistence (explicitly deferring boolean result tables to Phase 2), plus proposed writer layering, backend selection/compare-mode expectations, and a **CLI + SQL-only** validation plan and phased roadmap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6beb555b6751110bebea12249961b082bf75ad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->