### PR TITLE
feat(model-writer): add compare mode for dual-write parity validation (v3 C)

### DIFF
--- a/src/bin/verify_model_writer_trait.rs
+++ b/src/bin/verify_model_writer_trait.rs
@@ -16,6 +16,7 @@
 //!   4 — 注入值未被 backend 返回
 //!   5 — 二次 init / cleanup-without-init 安全性断言失败
 //!   6 — Parquet backend 端到端路径失败（v3 Phase B）
+//!   7 — Compare wrapper 端到端路径失败（v3 Phase C）
 
 #![cfg(feature = "model-writer-mock")]
 
@@ -30,9 +31,9 @@ use aios_core::geometry::ShapeInstancesData;
 use aios_database::fast_model::gen_model::canonical_records::CanonicalRawTable;
 use aios_database::fast_model::gen_model::mesh_generate::MeshResult;
 use aios_database::fast_model::gen_model::model_writer::{
-    BaseInstanceBatch, BooleanBridgeRequest, CleanupRequest, FinalizeRequest, InstRelateAabbBatch,
-    MeshResultBatch, ModelWriterBackend, ModelWriterContext, ParquetModelWriterBackend,
-    ReconcileRequest, RecordingBackend,
+    BaseInstanceBatch, BooleanBridgeRequest, CleanupRequest, CompareModelWriterBackend,
+    FinalizeRequest, InstRelateAabbBatch, MeshResultBatch, ModelWriterBackend, ModelWriterContext,
+    ParquetModelWriterBackend, ReconcileRequest, RecordingBackend,
 };
 use aios_database::options::{BooleanPipelineMode, ModelWriterMode};
 use dashmap::DashMap;
@@ -397,11 +398,168 @@ async fn main() -> ExitCode {
         return ExitCode::from(6);
     }
 
+    // ================================================================
+    // v3 Phase C：Compare wrapper 端到端路径
+    // Primary = RecordingBackend，Candidate = ParquetModelWriterBackend；
+    // 校验：(1) wrapper 所有 8 方法都成功；(2) primary 收到完整调用链；
+    //       (3) candidate 13 张 raw 表落盘；(4) wrapper.name() 仍是 "compare"。
+    // ================================================================
+    let compare_root = temp_subdir("verify-compare-wrapper");
+    if let Err(e) = std::fs::create_dir_all(&compare_root) {
+        eprintln!(
+            "[verify] FAIL: cannot create temp compare root {}: {}",
+            compare_root.display(),
+            e
+        );
+        return ExitCode::from(7);
+    }
+    let compare_primary_concrete = Arc::new(RecordingBackend::default());
+    let compare_primary: Arc<dyn ModelWriterBackend> = compare_primary_concrete.clone();
+    let compare_candidate: Arc<dyn ModelWriterBackend> = Arc::new(
+        ParquetModelWriterBackend::with_dbnum(compare_root.clone(), 0),
+    );
+    let compare_wrapper: Arc<dyn ModelWriterBackend> = Arc::new(CompareModelWriterBackend::new(
+        compare_primary.clone(),
+        compare_candidate.clone(),
+    ));
+    let compare_ctx = ModelWriterContext {
+        project_name: "verify-compare".to_string(),
+        use_surrealdb: false,
+        defer_db_write: false,
+        mode: ModelWriterMode::Parquet,
+    };
+    if compare_wrapper.name() != "compare" {
+        eprintln!(
+            "[verify] FAIL: compare wrapper name expected `compare`, got `{}`",
+            compare_wrapper.name()
+        );
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper.init(&compare_ctx).await {
+        eprintln!("[verify] FAIL: compare init: {}", e);
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper
+        .cleanup(CleanupRequest { seed_refnos: &[] })
+        .await
+    {
+        eprintln!("[verify] FAIL: compare cleanup: {}", e);
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper
+        .write_base_batch(BaseInstanceBatch {
+            batch_id: 1,
+            shape_insts: &shape_insts,
+            mesh_aabb_map: &mesh_aabb_map,
+            replace_exist: false,
+            write_inst_relate_aabb: false,
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: compare write_base_batch: {}", e);
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper
+        .persist_mesh_results(MeshResultBatch {
+            batch_id: 1,
+            mesh_results: &mesh_results,
+            mesh_aabb_map: &mesh_aabb_map,
+            mesh_pts_map: &mesh_pts_map,
+            file_mesh_state: false,
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: compare persist_mesh_results: {}", e);
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper
+        .write_inst_relate_aabb(InstRelateAabbBatch {
+            batch_id: 1,
+            shape_insts: &shape_insts,
+            mesh_results: &mesh_results,
+            mesh_aabb_map: &mesh_aabb_map,
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: compare write_inst_relate_aabb: {}", e);
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper
+        .reconcile_missing_neg(ReconcileRequest {
+            all_refnos: &[],
+            candidate_carriers: &[],
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: compare reconcile_missing_neg: {}", e);
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper
+        .run_boolean_bridge(BooleanBridgeRequest {
+            mode: BooleanPipelineMode::DbLegacy,
+            db_option: Arc::new(aios_core::options::DbOption::default()),
+            bool_tasks: Vec::new(),
+        })
+        .await
+    {
+        eprintln!("[verify] FAIL: compare run_boolean_bridge: {}", e);
+        return ExitCode::from(7);
+    }
+    if let Err(e) = compare_wrapper.finalize(FinalizeRequest::default()).await {
+        eprintln!("[verify] FAIL: compare finalize: {}", e);
+        return ExitCode::from(7);
+    }
+
+    // 校验 candidate 也产出了 13 张 canonical raw 表（compare wrapper 必须双写）
+    let compare_raw_root = compare_root.join("model_writer_storage").join("raw");
+    for table in CanonicalRawTable::all_phase1() {
+        let jsonl = compare_raw_root
+            .join(table.as_str())
+            .join(format!("project_name={}", compare_ctx.project_name))
+            .join(format!("dbnum={}", 0u32))
+            .join("batch_1.jsonl");
+        if !jsonl.exists() {
+            eprintln!(
+                "[verify] FAIL: compare candidate missing JSONL for `{}`: {}",
+                table.as_str(),
+                jsonl.display()
+            );
+            return ExitCode::from(7);
+        }
+    }
+
+    // 校验 primary（RecordingBackend）也收到全套调用
+    let compare_primary_methods: Vec<String> = compare_primary_concrete
+        .snapshot()
+        .iter()
+        .map(|line| line.split(':').next().unwrap_or("").to_string())
+        .collect();
+    let required_compare_methods = [
+        "init",
+        "cleanup",
+        "write_base_batch",
+        "persist_mesh_results",
+        "write_inst_relate_aabb",
+        "reconcile_missing_neg",
+        "run_boolean_bridge",
+        "finalize",
+    ];
+    for method in &required_compare_methods {
+        if !compare_primary_methods.iter().any(|m| m == method) {
+            eprintln!(
+                "[verify] FAIL: compare primary missed routed call `{}` (snapshot={:?})",
+                method, compare_primary_methods
+            );
+            return ExitCode::from(7);
+        }
+    }
+
     println!(
-        "[verify] PASS — 9 个 trait 调用按预期记录（含二次 init），注入值 reconcile={} missing_neg={} 均被 honored；Parquet backend 13 张 canonical raw 表 + 1 份 summary JSON 全部落盘，输出根 = {}",
+        "[verify] PASS — 9 个 trait 调用按预期记录（含二次 init），注入值 reconcile={} missing_neg={} 均被 honored；Parquet backend 13 张 canonical raw 表 + 1 份 summary JSON 全部落盘，输出根 = {}；Compare wrapper 双写到 primary + candidate 共 13 张 raw 表全部落盘，输出根 = {}",
         INJECTED_RECONCILE,
         injected_carriers.len(),
-        parquet_root.display()
+        parquet_root.display(),
+        compare_root.display()
     );
     for (idx, line) in snapshot.iter().enumerate() {
         println!("  [{}] {}", idx + 1, line);

--- a/src/fast_model/gen_model/model_writer/compare.rs
+++ b/src/fast_model/gen_model/model_writer/compare.rs
@@ -1,0 +1,390 @@
+//! Compare mode dual-write wrapper around two `ModelWriterBackend` impls.
+//!
+//! v3 Phase C：把 "candidate backend" 作为旁路写入器挂在主 backend 上，
+//! 让 orchestrator 在不修改调用点的情况下完成双写。语义遵循 mission
+//! `03-writer-architecture.md` §Error handling：**fail fast, no silent
+//! fallback** —— candidate 写失败立即 bail，绝不静默继续。
+//!
+//! 典型用法：`model_writer_mode = "surreal"` + `model_writer_compare_with = "parquet"`，
+//! 工厂会构造 `CompareModelWriterBackend::new(SurrealBackend, ParquetBackend)`。
+//!
+//! 调用顺序约定：
+//!
+//! 1. 先 primary，再 candidate。primary 失败 → 立即 bail（不动 candidate）；
+//!    primary 成功 → 调 candidate；candidate 失败 → 立即 bail（已写入 primary
+//!    无回滚，运维 / SQL parity 在 v3 Phase E 做事后比对）。
+//! 2. 报告（`WriteBaseReport`、`reconcile_missing_neg.inserted`、
+//!    `BooleanBridgeReport`、`FinalizeSummary`）以 **primary 为准** 返回；
+//!    candidate 的差异在 `[model-writer:compare]` 日志里逐条暴露，
+//!    供 Phase E `validate-compare` CLI 抓取。
+
+use async_trait::async_trait;
+
+use super::{
+    BaseInstanceBatch, BooleanBridgeReport, BooleanBridgeRequest, CleanupRequest, FinalizeRequest,
+    FinalizeSummary, InstRelateAabbBatch, MeshResultBatch, ModelWriterBackend, ModelWriterContext,
+    ReconcileRequest, WriteBaseReport,
+};
+
+use std::sync::Arc;
+
+/// Dual-write wrapper. See module doc for ordering + failure semantics.
+pub struct CompareModelWriterBackend {
+    primary: Arc<dyn ModelWriterBackend>,
+    candidate: Arc<dyn ModelWriterBackend>,
+}
+
+impl std::fmt::Debug for CompareModelWriterBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompareModelWriterBackend")
+            .field("primary", &self.primary.name())
+            .field("candidate", &self.candidate.name())
+            .finish()
+    }
+}
+
+impl CompareModelWriterBackend {
+    pub fn new(
+        primary: Arc<dyn ModelWriterBackend>,
+        candidate: Arc<dyn ModelWriterBackend>,
+    ) -> Self {
+        println!(
+            "[model-writer:compare] init wrapper primary={} candidate={} fail_fast=true",
+            primary.name(),
+            candidate.name()
+        );
+        Self { primary, candidate }
+    }
+
+    fn log(&self, stage: &str, key: &str, value: &str) {
+        println!(
+            "[model-writer:compare] stage={} primary={} candidate={} {}={}",
+            stage,
+            self.primary.name(),
+            self.candidate.name(),
+            key,
+            value
+        );
+    }
+}
+
+#[async_trait]
+impl ModelWriterBackend for CompareModelWriterBackend {
+    fn name(&self) -> &'static str {
+        // Static label; primary/candidate identities surface in every log line.
+        "compare"
+    }
+
+    async fn init(&self, context: &ModelWriterContext) -> anyhow::Result<()> {
+        self.log("init", "step", "primary");
+        self.primary.init(context).await.map_err(|e| {
+            anyhow::anyhow!(
+                "compare primary({}) init failed: {}",
+                self.primary.name(),
+                e
+            )
+        })?;
+        self.log("init", "step", "candidate");
+        self.candidate.init(context).await.map_err(|e| {
+            anyhow::anyhow!(
+                "compare candidate({}) init failed (fail-fast, no rollback on primary): {}",
+                self.candidate.name(),
+                e
+            )
+        })?;
+        Ok(())
+    }
+
+    async fn cleanup(&self, request: CleanupRequest<'_>) -> anyhow::Result<()> {
+        self.log(
+            "cleanup",
+            "seed_refnos",
+            &request.seed_refnos.len().to_string(),
+        );
+        let seeds = request.seed_refnos;
+        self.primary
+            .cleanup(CleanupRequest { seed_refnos: seeds })
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare primary({}) cleanup failed: {}",
+                    self.primary.name(),
+                    e
+                )
+            })?;
+        self.candidate
+            .cleanup(CleanupRequest { seed_refnos: seeds })
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare candidate({}) cleanup failed: {}",
+                    self.candidate.name(),
+                    e
+                )
+            })?;
+        Ok(())
+    }
+
+    async fn write_base_batch(
+        &self,
+        batch: BaseInstanceBatch<'_>,
+    ) -> anyhow::Result<WriteBaseReport> {
+        let batch_id = batch.batch_id;
+        let primary_batch = BaseInstanceBatch {
+            batch_id,
+            shape_insts: batch.shape_insts,
+            mesh_aabb_map: batch.mesh_aabb_map,
+            replace_exist: batch.replace_exist,
+            write_inst_relate_aabb: batch.write_inst_relate_aabb,
+        };
+        let candidate_batch = BaseInstanceBatch {
+            batch_id,
+            shape_insts: batch.shape_insts,
+            mesh_aabb_map: batch.mesh_aabb_map,
+            replace_exist: batch.replace_exist,
+            write_inst_relate_aabb: batch.write_inst_relate_aabb,
+        };
+
+        let primary = self
+            .primary
+            .write_base_batch(primary_batch)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare primary({}) write_base_batch({}) failed: {}",
+                    self.primary.name(),
+                    batch_id,
+                    e
+                )
+            })?;
+        let candidate = self
+            .candidate
+            .write_base_batch(candidate_batch)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare candidate({}) write_base_batch({}) failed: {}",
+                    self.candidate.name(),
+                    batch_id,
+                    e
+                )
+            })?;
+
+        if primary.missing_neg_count != candidate.missing_neg_count {
+            self.log(
+                "base_diff",
+                "missing_neg_count",
+                &format!(
+                    "primary={} candidate={} batch={}",
+                    primary.missing_neg_count, candidate.missing_neg_count, batch_id
+                ),
+            );
+        } else {
+            self.log("base", "batch_done", &batch_id.to_string());
+        }
+        Ok(primary)
+    }
+
+    async fn persist_mesh_results(&self, batch: MeshResultBatch<'_>) -> anyhow::Result<()> {
+        let batch_id = batch.batch_id;
+        let mesh_count = batch.mesh_results.len();
+        let primary_batch = MeshResultBatch {
+            batch_id,
+            mesh_results: batch.mesh_results,
+            mesh_aabb_map: batch.mesh_aabb_map,
+            mesh_pts_map: batch.mesh_pts_map,
+            file_mesh_state: batch.file_mesh_state,
+        };
+        let candidate_batch = MeshResultBatch {
+            batch_id,
+            mesh_results: batch.mesh_results,
+            mesh_aabb_map: batch.mesh_aabb_map,
+            mesh_pts_map: batch.mesh_pts_map,
+            file_mesh_state: batch.file_mesh_state,
+        };
+
+        self.primary
+            .persist_mesh_results(primary_batch)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare primary({}) persist_mesh_results({}) failed: {}",
+                    self.primary.name(),
+                    batch_id,
+                    e
+                )
+            })?;
+        self.candidate
+            .persist_mesh_results(candidate_batch)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare candidate({}) persist_mesh_results({}) failed: {}",
+                    self.candidate.name(),
+                    batch_id,
+                    e
+                )
+            })?;
+        self.log(
+            "mesh_results",
+            "batch_done",
+            &format!("batch={} mesh_results={}", batch_id, mesh_count),
+        );
+        Ok(())
+    }
+
+    async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()> {
+        let batch_id = batch.batch_id;
+        let primary_batch = InstRelateAabbBatch {
+            batch_id,
+            shape_insts: batch.shape_insts,
+            mesh_results: batch.mesh_results,
+            mesh_aabb_map: batch.mesh_aabb_map,
+        };
+        let candidate_batch = InstRelateAabbBatch {
+            batch_id,
+            shape_insts: batch.shape_insts,
+            mesh_results: batch.mesh_results,
+            mesh_aabb_map: batch.mesh_aabb_map,
+        };
+        self.primary
+            .write_inst_relate_aabb(primary_batch)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare primary({}) write_inst_relate_aabb({}) failed: {}",
+                    self.primary.name(),
+                    batch_id,
+                    e
+                )
+            })?;
+        self.candidate
+            .write_inst_relate_aabb(candidate_batch)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare candidate({}) write_inst_relate_aabb({}) failed: {}",
+                    self.candidate.name(),
+                    batch_id,
+                    e
+                )
+            })?;
+        self.log("inst_relate_aabb", "batch_done", &batch_id.to_string());
+        Ok(())
+    }
+
+    async fn reconcile_missing_neg(&self, request: ReconcileRequest<'_>) -> anyhow::Result<usize> {
+        let primary_req = ReconcileRequest {
+            all_refnos: request.all_refnos,
+            candidate_carriers: request.candidate_carriers,
+        };
+        let candidate_req = ReconcileRequest {
+            all_refnos: request.all_refnos,
+            candidate_carriers: request.candidate_carriers,
+        };
+
+        let primary_inserted =
+            self.primary
+                .reconcile_missing_neg(primary_req)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "compare primary({}) reconcile_missing_neg failed: {}",
+                        self.primary.name(),
+                        e
+                    )
+                })?;
+        let candidate_inserted = self
+            .candidate
+            .reconcile_missing_neg(candidate_req)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "compare candidate({}) reconcile_missing_neg failed: {}",
+                    self.candidate.name(),
+                    e
+                )
+            })?;
+
+        if primary_inserted != candidate_inserted {
+            self.log(
+                "reconcile_diff",
+                "inserted",
+                &format!(
+                    "primary={} candidate={} (candidate may be approximate, e.g. parquet)",
+                    primary_inserted, candidate_inserted
+                ),
+            );
+        }
+        Ok(primary_inserted)
+    }
+
+    async fn run_boolean_bridge(
+        &self,
+        request: BooleanBridgeRequest,
+    ) -> anyhow::Result<BooleanBridgeReport> {
+        // BooleanBridgeRequest 不是 Copy；按 mission 03 仅做单写到 primary，
+        // candidate 按约定走 skipped pipeline（Parquet/DuckLake 当前都跳过 boolean）。
+        // 这与 mission 05 §Phase boundary 一致：boolean 是 Phase 2 范围。
+        let primary_report = self.primary.run_boolean_bridge(request).await.map_err(|e| {
+            anyhow::anyhow!(
+                "compare primary({}) run_boolean_bridge failed: {}",
+                self.primary.name(),
+                e
+            )
+        })?;
+        self.log(
+            "boolean_bridge",
+            "primary_pipeline",
+            primary_report.pipeline,
+        );
+        // candidate 不带 db_option 时如何 fan-out 是 v4 BridgeContext 的工作。
+        // 当前 candidate boolean 跳过，避免误传 DbOption 给 file backend。
+        println!(
+            "[model-writer:compare] stage=boolean_bridge candidate({}) skipped reason=mission_03_phase2_boolean_only_routed_to_primary",
+            self.candidate.name()
+        );
+        Ok(primary_report)
+    }
+
+    async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary> {
+        let primary_req = FinalizeRequest {
+            total_batches: request.total_batches,
+            completed_batches: request.completed_batches,
+            mesh_cache_hits: request.mesh_cache_hits,
+            mesh_new_generated: request.mesh_new_generated,
+            missing_neg_candidates: request.missing_neg_candidates,
+        };
+        let candidate_req = FinalizeRequest {
+            total_batches: request.total_batches,
+            completed_batches: request.completed_batches,
+            mesh_cache_hits: request.mesh_cache_hits,
+            mesh_new_generated: request.mesh_new_generated,
+            missing_neg_candidates: request.missing_neg_candidates,
+        };
+
+        let primary_summary = self.primary.finalize(primary_req).await.map_err(|e| {
+            anyhow::anyhow!(
+                "compare primary({}) finalize failed: {}",
+                self.primary.name(),
+                e
+            )
+        })?;
+        let candidate_summary = self.candidate.finalize(candidate_req).await.map_err(|e| {
+            anyhow::anyhow!(
+                "compare candidate({}) finalize failed: {}",
+                self.candidate.name(),
+                e
+            )
+        })?;
+        println!(
+            "[model-writer:compare] stage=finalize primary={} primary_completed={} candidate={} candidate_completed={} total_batches={}",
+            primary_summary.backend,
+            primary_summary.completed_batches,
+            candidate_summary.backend,
+            candidate_summary.completed_batches,
+            request.total_batches
+        );
+        Ok(primary_summary)
+    }
+}

--- a/src/fast_model/gen_model/model_writer/mod.rs
+++ b/src/fast_model/gen_model/model_writer/mod.rs
@@ -18,12 +18,14 @@ pub use super::canonical_records::{
     CanonicalRawBatch, CanonicalRawPlanner, CanonicalRawRowCounts, CanonicalRawTable,
 };
 
+mod compare;
 mod drain_only;
 #[cfg(feature = "model-writer-mock")]
 mod mock;
 mod parquet;
 mod surreal;
 
+pub use compare::CompareModelWriterBackend;
 pub use drain_only::{DrainOnlyModelWriterBackend, DrainOnlyStats, run_drain_only_sink};
 #[cfg(feature = "model-writer-mock")]
 pub use mock::RecordingBackend;
@@ -214,8 +216,13 @@ pub trait ModelWriterBackend: Send + Sync {
     async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary>;
 }
 
-pub fn create_model_writer(db_option: &DbOptionExt) -> anyhow::Result<Arc<dyn ModelWriterBackend>> {
-    let backend: Arc<dyn ModelWriterBackend> = match db_option.model_writer_mode {
+/// Build a single backend instance for the given mode. Used both for the
+/// primary backend and (when configured) for the compare-mode candidate.
+fn build_single_backend(
+    db_option: &DbOptionExt,
+    mode: ModelWriterMode,
+) -> anyhow::Result<Arc<dyn ModelWriterBackend>> {
+    let backend: Arc<dyn ModelWriterBackend> = match mode {
         ModelWriterMode::Surreal => Arc::new(SurrealModelWriterBackend::default()),
         ModelWriterMode::DrainOnly => Arc::new(DrainOnlyModelWriterBackend::default()),
         ModelWriterMode::Parquet => {
@@ -235,9 +242,42 @@ pub fn create_model_writer(db_option: &DbOptionExt) -> anyhow::Result<Arc<dyn Mo
             ))
         }
     };
+    Ok(backend)
+}
+
+pub fn create_model_writer(db_option: &DbOptionExt) -> anyhow::Result<Arc<dyn ModelWriterBackend>> {
+    let primary = build_single_backend(db_option, db_option.model_writer_mode)?;
+
+    // v3 Phase C: compare mode dual-write wrapper.
+    if let Some(candidate_mode) = db_option.model_writer_compare_with {
+        if candidate_mode == db_option.model_writer_mode {
+            anyhow::bail!(
+                "model_writer_compare_with={} duplicates primary model_writer_mode={}; remove compare_with or pick a different backend",
+                candidate_mode.as_str(),
+                db_option.model_writer_mode.as_str()
+            );
+        }
+        if matches!(candidate_mode, ModelWriterMode::DrainOnly) {
+            anyhow::bail!(
+                "model_writer_compare_with=drain-only is not supported: DrainOnly is a baseline sink, not a candidate writer (mission docs/05 + v2 invariant)"
+            );
+        }
+        let candidate = build_single_backend(db_option, candidate_mode)?;
+        let wrapper = Arc::new(CompareModelWriterBackend::new(
+            primary.clone(),
+            candidate.clone(),
+        ));
+        println!(
+            "[model-writer] factory selected primary={} mirror={} fail_fast=true wrapper=compare",
+            primary.name(),
+            candidate.name()
+        );
+        return Ok(wrapper);
+    }
+
     println!(
         "[model-writer] factory selected primary={} mirror=none fail_fast=true",
-        backend.name()
+        primary.name()
     );
-    Ok(backend)
+    Ok(primary)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -661,6 +661,13 @@ async fn main() -> anyhow::Result<()> {
                 .value_name("DBNUM"),
         )
         .arg(
+            Arg::new("model-writer-compare-with")
+                .long("model-writer-compare-with")
+                .help("v3 Phase C compare mode: dual-write to candidate backend (surreal|parquet). Fail-fast on any candidate write failure (mission 03 §Error handling). drain-only is NOT a valid candidate.")
+                .value_name("BACKEND")
+                .value_parser(["surreal", "parquet"]),
+        )
+        .arg(
             Arg::new("export-parquet-after-gen")
                 .long("export-parquet-after-gen")
                 .help("After model generation, automatically export Parquet for each dbnum in manual_db_nums (instances/tubings/transforms/aabb)")
@@ -1208,6 +1215,23 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!("parquet-dbnum 必须是 u32，传入 `{dbnum_raw}`: {e}"))?;
         db_option_ext.parquet_model_writer_dbnum = Some(dbnum);
         println!("🔧 parquet model-writer dbnum: {}", dbnum);
+    }
+    if let Some(candidate_raw) = matches.get_one::<String>("model-writer-compare-with") {
+        let candidate = match candidate_raw.as_str() {
+            "surreal" => ModelWriterMode::Surreal,
+            "parquet" => ModelWriterMode::Parquet,
+            other => {
+                return Err(anyhow::anyhow!(
+                    "model-writer-compare-with 不支持值 `{other}`（仅 surreal | parquet）"
+                ));
+            }
+        };
+        db_option_ext.model_writer_compare_with = Some(candidate);
+        println!(
+            "🔧 model-writer compare mode 已启用: primary={} candidate={} fail_fast=true",
+            db_option_ext.model_writer_mode.as_str(),
+            candidate.as_str()
+        );
     }
     db_option_ext.validate_model_writer_features()?;
     if let Some(backend) = matches.get_one::<String>("transform-write-backend") {

--- a/src/options.rs
+++ b/src/options.rs
@@ -391,6 +391,18 @@ pub struct DbOptionExt {
     #[serde(default)]
     pub parquet_model_writer_dbnum: Option<u32>,
 
+    /// Compare 模式 candidate backend：当 Some 时构造
+    /// `CompareModelWriterBackend(primary=model_writer_mode, candidate=this)`
+    /// 让 orchestrator 在不修改调用点的情况下完成双写 + 行级 diff 日志。
+    /// 失败语义遵循 mission `03-writer-architecture.md` §Error handling
+    /// （fail fast，禁止静默回退）。
+    ///
+    /// 约束：
+    /// - 不允许等于 primary（自我比较无意义）
+    /// - 不允许 `drain-only`（DrainOnly 是 baseline sink，非 candidate writer）
+    #[serde(default)]
+    pub model_writer_compare_with: Option<ModelWriterMode>,
+
     /// pe_transform 刷新结果写入后端。
     #[serde(default = "default_transform_write_backend")]
     pub transform_write_backend: TransformWriteBackend,
@@ -640,6 +652,35 @@ impl DbOptionExt {
             }
         }
 
+        // 2c) compare_with 合法性早期拒绝（mission 03 §Error handling: fail fast）
+        if let Some(candidate) = self.model_writer_compare_with {
+            if candidate == self.model_writer_mode {
+                anyhow::bail!(
+                    "model_writer_compare_with={} 与 model_writer={} 一致；移除 compare_with 或换不同后端",
+                    candidate.as_str(),
+                    self.model_writer_mode.as_str()
+                );
+            }
+            if matches!(candidate, ModelWriterMode::DrainOnly) {
+                anyhow::bail!(
+                    "model_writer_compare_with=drain-only 不被支持：DrainOnly 是 baseline 模式而非 candidate writer（mission docs/05 + v2 invariant）"
+                );
+            }
+            // candidate=parquet 需要 output_root；复用 2b 守卫语义
+            if matches!(candidate, ModelWriterMode::Parquet) {
+                let root = self
+                    .parquet_model_writer_output_root
+                    .as_ref()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty());
+                if root.is_none() {
+                    anyhow::bail!(
+                        "model_writer_compare_with=parquet 要求 parquet_model_writer_output_root 非空"
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -704,6 +745,7 @@ impl From<DbOption> for DbOptionExt {
             model_writer_mode: ModelWriterMode::Surreal,
             parquet_model_writer_output_root: None,
             parquet_model_writer_dbnum: None,
+            model_writer_compare_with: None,
             transform_write_backend: TransformWriteBackend::Surreal,
             transform_read_backend: TransformReadBackend::Auto,
             transform_compare_backends: Vec::new(),
@@ -992,6 +1034,17 @@ pub fn get_db_option_ext_from_path(config_path: &str) -> anyhow::Result<DbOption
         .and_then(|v| v.as_integer())
         .and_then(|v| u32::try_from(v).ok());
 
+    let model_writer_compare_with = toml_value
+        .get("model_writer_compare_with")
+        .and_then(|v| v.as_str())
+        .and_then(|s| match s.trim().to_ascii_lowercase().as_str() {
+            "surreal" => Some(ModelWriterMode::Surreal),
+            "parquet" => Some(ModelWriterMode::Parquet),
+            // drain-only is intentionally excluded (baseline sink, not a candidate writer);
+            // unknown values fall through to None.
+            _ => None,
+        });
+
     // 构建 DbOptionExt
     let db_option_ext = DbOptionExt {
         inner: db_option,
@@ -1016,6 +1069,7 @@ pub fn get_db_option_ext_from_path(config_path: &str) -> anyhow::Result<DbOption
         model_writer_mode,
         parquet_model_writer_output_root,
         parquet_model_writer_dbnum,
+        model_writer_compare_with,
         transform_write_backend,
         transform_read_backend,
         transform_compare_backends,


### PR DESCRIPTION
## Summary

v3 Phase C: introduces **compare mode** for the model writer — a trait-level dual-write decorator that wraps any two `ModelWriterBackend` impls and fans every call out to primary then candidate with fail-fast semantics. Orchestrator stays zero-touch (no signature changes); the wrapper is selected by `create_model_writer` when `model_writer_compare_with` is set.

Based on `feat/parquet-model-writer-backend` (PR #14). Companion docs:
- v3 plan: `docs/plans/2026-05-09-model-write-trait-followup/v3-plan.md` (PR #11)
- mission 03 `writer-architecture.md` §Error handling — fail fast, no silent fallback
- mission 06 `orchestrator-integration.md` §Compatibility — every new backend proves parity through CLI + SQL before becoming primary

## Phase C commit slices

| Commit | Scope |
|---|---|
| `2401268b` | C.1 — `CompareModelWriterBackend` wrapper + diff-log policy |
| `fb79afa8` | C.2 — Factory + `DbOptionExt::model_writer_compare_with` + CLI flag + validate guards |
| `3300ed7d` | C.3 — `verify_model_writer_trait` Compare end-to-end path (exit code 7) |

## Wrapper semantics

| Trait method | Compare mode behavior |
|---|---|
| `init` | primary → candidate; either failure bails (no rollback on the other side) |
| `cleanup` | primary → candidate |
| `write_base_batch` | primary → candidate; returns primary's report; diff log if `missing_neg_count` mismatches |
| `persist_mesh_results` | primary → candidate |
| `write_inst_relate_aabb` | primary → candidate |
| `reconcile_missing_neg` | primary → candidate; returns primary's inserted; diff log if counts differ (candidate=parquet returns approximate=0) |
| `run_boolean_bridge` | primary only; candidate emits `mission_03_phase2_boolean_only_routed_to_primary` skip log (BooleanBridgeRequest is non-Copy, boolean tables are Phase 2) |
| `finalize` | primary → candidate; logs both summaries; returns primary |

`wrapper.name()` is static `"compare"`. Primary/candidate identities surface in every `[model-writer:compare] stage=... primary=... candidate=...` log line for downstream parsing (Phase E `validate-compare` CLI).

## Configuration

```toml
# DbOption TOML / DbOptionExt
model_writer_mode = "surreal"
model_writer_compare_with = "parquet"       # candidate backend
parquet_model_writer_output_root = "output/compare-runs"
parquet_model_writer_dbnum = 1
```

```bash
aios-database --model-writer surreal \
              --model-writer-compare-with parquet \
              --parquet-output-root output/compare-runs \
              --parquet-dbnum 1
```

## Guards (early rejection, mission 03 fail-fast)

`validate_model_writer_features` rejects:

- `compare_with == model_writer_mode` (self-comparison meaningless)
- `compare_with == "drain-only"` (DrainOnly is a baseline sink per v2 invariant, not a candidate writer)
- `compare_with == "parquet"` without `parquet_model_writer_output_root`

The factory mirrors these guards as defense-in-depth.

## Test plan

- [x] `cargo check --bin aios-database --features review` passes
- [x] `cargo run --bin verify_model_writer_trait --features model-writer-mock` → PASS
  - Mock 9 trait calls in expected order
  - Parquet end-to-end: 13 canonical raw tables + summary JSON
  - **Compare end-to-end: wrapper.name()=="compare", primary (mock) snapshot covers all 8 method names, candidate (parquet) emits 13 JSONL tables**
- [ ] Reviewer: confirm wrapper diff-log policy (currently `missing_neg_count` only; expand in Phase E if needed)
- [ ] Reviewer: `run_boolean_bridge` single-primary policy acceptable for Phase 2 boolean scope?

## Architecture invariants honored

1. DrainOnly fast path & semantics untouched (v2)
2. Surreal backend untouched (no SQL changes)
3. Boolean tables remain Phase 2 (mission 05)
4. No new crate dependencies
5. `[model-writer:*]` log prefix contract preserved (`[model-writer:compare]` added)
6. Fail fast, no silent fallback (mission 03 §Error handling)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `CompareModelWriterBackend` and wires it into the model-writer factory/CLI/options, which changes how persistence backends can be selected and executed during model generation. Fail-fast dual-write can cause new run-time aborts and partial primary writes if the candidate backend fails.
> 
> **Overview**
> Adds **compare mode** for model writing by introducing `CompareModelWriterBackend`, a trait-level wrapper that routes writes to a *primary* backend then a *candidate* backend with **fail-fast** error handling and lightweight diff logging (reports still return the primary result; boolean bridge is routed to primary only).
> 
> Extends configuration and CLI to enable this (`DbOptionExt.model_writer_compare_with`, TOML parsing, `--model-writer-compare-with`), adds validation/guards against invalid combinations, and updates the model-writer factory to build and return the wrapper when configured.
> 
> Expands `verify_model_writer_trait` with an end-to-end compare-wrapper test path (new exit code `7`) that asserts calls are routed to the primary and that the candidate backend produces expected Parquet canonical raw outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3300ed7d6f04dea9b3d8b4a87d126f09ae3729c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->