### PR TITLE
feat(model-writer): add DuckLake backend skeleton behind ducklake feature (v3 D)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,6 +255,10 @@ surreal-save = []
 write-to-surrealdb = []
 # Mock backend：仅供 trait 契约验证 binary 使用，不进 release。
 model-writer-mock = []
+# v3 Phase D：DuckLake backend skeleton。仅为 v4 真实实装预留 trait 接口面 +
+# 工厂分支。当前实现全部 `bail!("not yet implemented")`，不引入 duckdb crate
+# 依赖。启用方式：`cargo check --features ducklake`。默认不开启，避免污染生产构建。
+ducklake = []
 test = ["aios_core/test"]
 mem-kv-save = ["aios_core/mem-kv-save"] #额外保存PE数据到内存KV数据库
 kv-rocksdb = [

--- a/src/fast_model/gen_model/model_writer/ducklake.rs
+++ b/src/fast_model/gen_model/model_writer/ducklake.rs
@@ -1,0 +1,99 @@
+//! DuckLake backend skeleton — v3 Phase D placeholder for v4 real implementation.
+//!
+//! mission `04-ducklake-writer.md` 把 DuckLake target design 定为
+//! "通过 Rust DuckDB binding 直接写 ducklake-canonical schema"。v3 范围
+//! 不实装真实写入（避免引入 `duckdb` crate 依赖污染本轮 review）；本骨架
+//! 只承担三件事：
+//!
+//! 1. 占住 `ModelWriterMode::DuckLake` 在工厂里的分支
+//! 2. 给 trait 8 个方法一个具体 impl，便于 v4 直接填充
+//! 3. 让 `cargo check --features ducklake` 编过，以便后续 PR 在 feature 开启
+//!    的情况下迭代真实写入
+//!
+//! 所有 trait 方法返回 `bail!("DuckLake backend skeleton, not yet implemented
+//! (mission docs/04). Use parquet/surreal in v3.")`，确保**任何**误用都会
+//! 立即失败而不是静默成功。`init` 也是 `bail!`，因为没有任何后续 stage 能
+//! 真正持久化数据；让生产端在 init 阶段就被打断，避免空跑生成 pipeline。
+
+#![cfg(feature = "ducklake")]
+
+use async_trait::async_trait;
+
+use super::{
+    BaseInstanceBatch, BooleanBridgeReport, BooleanBridgeRequest, CleanupRequest, FinalizeRequest,
+    FinalizeSummary, InstRelateAabbBatch, MeshResultBatch, ModelWriterBackend, ModelWriterContext,
+    ReconcileRequest, WriteBaseReport,
+};
+
+/// DuckLake backend skeleton. **All trait methods bail.** v4 will replace these
+/// with real implementations backed by the Rust DuckDB binding.
+#[derive(Debug, Default)]
+pub struct DuckLakeModelWriterBackend {
+    /// v4 will hold the duckdb connection + ducklake metadata path here.
+    /// Kept as ZST during the skeleton phase to avoid unused-field churn.
+    _phantom: (),
+}
+
+impl DuckLakeModelWriterBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+fn not_implemented(stage: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "[model-writer:ducklake] stage={} DuckLake backend skeleton, not yet implemented (mission docs/04-ducklake-writer.md). Use --model-writer parquet|surreal in v3; real DuckLake support lands in v4 with the duckdb crate.",
+        stage
+    )
+}
+
+#[async_trait]
+impl ModelWriterBackend for DuckLakeModelWriterBackend {
+    fn name(&self) -> &'static str {
+        "ducklake"
+    }
+
+    async fn init(&self, _context: &ModelWriterContext) -> anyhow::Result<()> {
+        Err(not_implemented("init"))
+    }
+
+    async fn cleanup(&self, _request: CleanupRequest<'_>) -> anyhow::Result<()> {
+        Err(not_implemented("cleanup"))
+    }
+
+    async fn write_base_batch(
+        &self,
+        _batch: BaseInstanceBatch<'_>,
+    ) -> anyhow::Result<WriteBaseReport> {
+        Err(not_implemented("write_base_batch"))
+    }
+
+    async fn persist_mesh_results(&self, _batch: MeshResultBatch<'_>) -> anyhow::Result<()> {
+        Err(not_implemented("persist_mesh_results"))
+    }
+
+    async fn write_inst_relate_aabb(
+        &self,
+        _batch: InstRelateAabbBatch<'_>,
+    ) -> anyhow::Result<()> {
+        Err(not_implemented("write_inst_relate_aabb"))
+    }
+
+    async fn reconcile_missing_neg(
+        &self,
+        _request: ReconcileRequest<'_>,
+    ) -> anyhow::Result<usize> {
+        Err(not_implemented("reconcile_missing_neg"))
+    }
+
+    async fn run_boolean_bridge(
+        &self,
+        _request: BooleanBridgeRequest,
+    ) -> anyhow::Result<BooleanBridgeReport> {
+        Err(not_implemented("run_boolean_bridge"))
+    }
+
+    async fn finalize(&self, _request: FinalizeRequest) -> anyhow::Result<FinalizeSummary> {
+        Err(not_implemented("finalize"))
+    }
+}

--- a/src/fast_model/gen_model/model_writer/mod.rs
+++ b/src/fast_model/gen_model/model_writer/mod.rs
@@ -20,6 +20,8 @@ pub use super::canonical_records::{
 
 mod compare;
 mod drain_only;
+#[cfg(feature = "ducklake")]
+mod ducklake;
 #[cfg(feature = "model-writer-mock")]
 mod mock;
 mod parquet;
@@ -27,6 +29,8 @@ mod surreal;
 
 pub use compare::CompareModelWriterBackend;
 pub use drain_only::{DrainOnlyModelWriterBackend, DrainOnlyStats, run_drain_only_sink};
+#[cfg(feature = "ducklake")]
+pub use ducklake::DuckLakeModelWriterBackend;
 #[cfg(feature = "model-writer-mock")]
 pub use mock::RecordingBackend;
 // Canonical raw sink scaffold + v3 Phase B ModelWriterBackend impl (file-oriented).
@@ -240,6 +244,18 @@ fn build_single_backend(
                     .parquet_model_writer_dbnum
                     .unwrap_or(ParquetModelWriterBackend::DEFAULT_DBNUM),
             ))
+        }
+        ModelWriterMode::DuckLake => {
+            #[cfg(feature = "ducklake")]
+            {
+                Arc::new(DuckLakeModelWriterBackend::new())
+            }
+            #[cfg(not(feature = "ducklake"))]
+            {
+                anyhow::bail!(
+                    "model_writer=ducklake requires --features ducklake build (v3 Phase D skeleton, real implementation lands in v4 per mission docs/04-ducklake-writer.md)"
+                )
+            }
         }
     };
     Ok(backend)

--- a/src/main.rs
+++ b/src/main.rs
@@ -644,9 +644,9 @@ async fn main() -> anyhow::Result<()> {
         .arg(
             Arg::new("model-writer")
                 .long("model-writer")
-                .help("Model writer backend: surreal writes to SurrealDB; drain-only consumes generated batches for throughput testing without persistence; parquet emits canonical raw JSONL under parquet-output-root")
+                .help("Model writer backend: surreal writes to SurrealDB; drain-only consumes generated batches for throughput testing without persistence; parquet emits canonical raw JSONL under parquet-output-root; ducklake is a v3 Phase D skeleton (requires --features ducklake build, all trait methods bail until v4)")
                 .value_name("WRITER")
-                .value_parser(["surreal", "drain-only", "parquet"]),
+                .value_parser(["surreal", "drain-only", "parquet", "ducklake"]),
         )
         .arg(
             Arg::new("parquet-output-root")
@@ -663,9 +663,9 @@ async fn main() -> anyhow::Result<()> {
         .arg(
             Arg::new("model-writer-compare-with")
                 .long("model-writer-compare-with")
-                .help("v3 Phase C compare mode: dual-write to candidate backend (surreal|parquet). Fail-fast on any candidate write failure (mission 03 §Error handling). drain-only is NOT a valid candidate.")
+                .help("v3 Phase C compare mode: dual-write to candidate backend (surreal|parquet|ducklake). Fail-fast on any candidate write failure (mission 03 §Error handling). drain-only is NOT a valid candidate. ducklake requires --features ducklake build.")
                 .value_name("BACKEND")
-                .value_parser(["surreal", "parquet"]),
+                .value_parser(["surreal", "parquet", "ducklake"]),
         )
         .arg(
             Arg::new("export-parquet-after-gen")
@@ -1187,6 +1187,7 @@ async fn main() -> anyhow::Result<()> {
         db_option_ext.model_writer_mode = match writer.as_str() {
             "drain-only" => ModelWriterMode::DrainOnly,
             "parquet" => ModelWriterMode::Parquet,
+            "ducklake" => ModelWriterMode::DuckLake,
             _ => ModelWriterMode::Surreal,
         };
         println!(
@@ -1200,6 +1201,11 @@ async fn main() -> anyhow::Result<()> {
             ModelWriterMode::Parquet => {
                 println!(
                     "🔧 parquet 模式: canonical raw records 落 JSONL，到 parquet_model_writer_output_root（mission 05 §Layout）"
+                );
+            }
+            ModelWriterMode::DuckLake => {
+                println!(
+                    "🔧 ducklake 模式: v3 Phase D 占位骨架（需 --features ducklake 编译），所有 trait 方法 bail!；真实写入留 v4（mission 04-ducklake-writer.md）"
                 );
             }
             ModelWriterMode::Surreal => {}
@@ -1220,9 +1226,10 @@ async fn main() -> anyhow::Result<()> {
         let candidate = match candidate_raw.as_str() {
             "surreal" => ModelWriterMode::Surreal,
             "parquet" => ModelWriterMode::Parquet,
+            "ducklake" => ModelWriterMode::DuckLake,
             other => {
                 return Err(anyhow::anyhow!(
-                    "model-writer-compare-with 不支持值 `{other}`（仅 surreal | parquet）"
+                    "model-writer-compare-with 不支持值 `{other}`（仅 surreal | parquet | ducklake）"
                 ));
             }
         };

--- a/src/options.rs
+++ b/src/options.rs
@@ -65,6 +65,9 @@ fn parse_model_writer_mode(raw: Option<&str>) -> ModelWriterMode {
             ModelWriterMode::DrainOnly
         }
         Some(mode) if mode == "parquet" => ModelWriterMode::Parquet,
+        Some(mode) if mode == "ducklake" || mode == "duck-lake" || mode == "duck_lake" => {
+            ModelWriterMode::DuckLake
+        }
         Some(_) | None => ModelWriterMode::Surreal,
     }
 }
@@ -143,6 +146,10 @@ pub enum ModelWriterMode {
     /// raw records，落 JSONL（Phase 1 fallback）到 `parquet_model_writer_output_root`
     /// 指定的目录。typed Parquet 物化推迟到 v4。
     Parquet,
+    /// DuckLake target backend per mission docs/04-ducklake-writer.md。
+    /// v3 仅占位骨架（需 `--features ducklake` 编译），所有 trait 方法 `bail!`；
+    /// 真实写入实装留 v4。未启 feature 时工厂直接拒绝。
+    DuckLake,
 }
 
 impl Default for ModelWriterMode {
@@ -157,6 +164,7 @@ impl ModelWriterMode {
             Self::Surreal => "surreal",
             Self::DrainOnly => "drain-only",
             Self::Parquet => "parquet",
+            Self::DuckLake => "ducklake",
         }
     }
 
@@ -628,6 +636,13 @@ impl DbOptionExt {
             ModelWriterMode::DrainOnly => return Ok(()),
             // parquet 走文件系统，无需 storage feature；但需要 output_root 配置（运行时守卫见下方 2b）。
             ModelWriterMode::Parquet => {}
+            // ducklake feature 检查（v3 Phase D：仅 feature-gated 骨架）。
+            ModelWriterMode::DuckLake if !cfg!(feature = "ducklake") => {
+                anyhow::bail!(
+                    "model_writer=ducklake 需要 --features ducklake 编译；v3 Phase D 仅占位骨架，真实写入留 v4（mission docs/04-ducklake-writer.md）"
+                )
+            }
+            ModelWriterMode::DuckLake => {}
             _ => {}
         }
 
@@ -1040,6 +1055,7 @@ pub fn get_db_option_ext_from_path(config_path: &str) -> anyhow::Result<DbOption
         .and_then(|s| match s.trim().to_ascii_lowercase().as_str() {
             "surreal" => Some(ModelWriterMode::Surreal),
             "parquet" => Some(ModelWriterMode::Parquet),
+            "ducklake" | "duck-lake" | "duck_lake" => Some(ModelWriterMode::DuckLake),
             // drain-only is intentionally excluded (baseline sink, not a candidate writer);
             // unknown values fall through to None.
             _ => None,


### PR DESCRIPTION
## Summary

v3 Phase D: lands a **feature-gated DuckLake backend skeleton** to occupy `ModelWriterMode::DuckLake` and the trait surface, so that v4 can drop in the real Rust-DuckDB-binding implementation on top of mission `docs/04-ducklake-writer.md` without touching the trait contract.

**This PR ships a placeholder only.** All 8 trait methods bail with a uniform "skeleton, not yet implemented" error. No `duckdb` / `arrow` / `parquet` crate dependency introduced.

Based on `feat/model-writer-compare-mode` (PR #15). Stack:

```
PR #11 (v2 trait + v3 plan)
  └─ PR #14 (Parquet backend)
       └─ PR #15 (Compare mode wrapper)
            └─ PR #16 (this) — DuckLake skeleton
```

## Why ship a skeleton

mission `04-ducklake-writer.md` defines the target as "Rust DuckDB binding writes `ducklake-canonical` schema directly". v3 deliberately stops short of that to:

1. Avoid pulling the `duckdb` crate (and its bundled C++ build) into the trait abstraction PR cycle
2. Validate the `ModelWriterMode::DuckLake` factory branch + CLI surface + compare-mode candidate slot **right now** so v4 only changes the impl body
3. Surface "wrong build" misuse via a clear error in `create_model_writer` rather than letting users hit it deep inside the generation pipeline

## Scope

| File | Change |
|---|---|
| `Cargo.toml` | new feature `ducklake = []` (no crate deps yet) |
| `model_writer/ducklake.rs` | `#[cfg(feature = "ducklake")]` skeleton; ZST + all 8 trait methods bail |
| `model_writer/mod.rs` | cfg-gated module + re-export + factory branch (compile-time guard) |
| `options.rs` | `ModelWriterMode::DuckLake`, parse `ducklake`/`duck-lake`/`duck_lake`, validate feature, compare_with accepts ducklake |
| `main.rs` | `--model-writer ducklake` + `--model-writer-compare-with ducklake` (with help text pointing to `--features ducklake`) |

## Bail surface

When a user runs without the feature:

```
$ aios-database --model-writer ducklake
[…] model_writer=ducklake 需要 --features ducklake 编译；v3 Phase D 仅占位骨架，真实写入留 v4（mission docs/04-ducklake-writer.md）
```

When the feature is enabled but they actually start writing:

```
$ aios-database --model-writer ducklake --features ducklake build
[model-writer:ducklake] stage=init DuckLake backend skeleton, not yet implemented (mission docs/04-ducklake-writer.md). Use --model-writer parquet|surreal in v3; real DuckLake support lands in v4 with the duckdb crate.
```

## Test plan

- [x] `cargo check --bin aios-database --features review` (ducklake disabled) — OK
- [x] `cargo check --bin aios-database --features "review,ducklake"` (skeleton compiles) — OK
- [x] `ReadLints` on all 5 changed files — no errors
- [ ] Reviewer: confirm `bail!` text on every method is acceptable (vs. `unimplemented!()`)
- [ ] Reviewer: confirm `Compare(primary=surreal, candidate=ducklake)` is allowed even though candidate will bail (current factory does not reject this combo; alternative is to forbid until v4)

## Architecture invariants honored

1. DrainOnly fast path & semantics untouched (v2)
2. Surreal backend untouched
3. Parquet / Compare backends untouched
4. **Zero new crate dependencies** (this is the key constraint v3 promised)
5. `[model-writer:*]` log prefix preserved (`[model-writer:ducklake]` added)
6. Fail fast on misuse (no silent fallback to other backends)

## v4 follow-up

When DuckLake gets real implementation, replace the `bail!` bodies and pull in `duckdb` crate behind the same `ducklake` feature. The trait contract, factory wiring, options, CLI, and validate guards stay as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because the DuckLake path is fully feature-gated and fail-fast (all methods return errors), so existing Surreal/Parquet/DrainOnly behavior is unchanged unless users explicitly opt in.
> 
> **Overview**
> Introduces a new `ducklake` Cargo feature and a **DuckLake model-writer backend skeleton** that wires `ModelWriterMode::DuckLake` through the factory, but intentionally `bail!`s on `init` and all other trait methods.
> 
> Extends config parsing/validation and CLI flags to accept `--model-writer ducklake` and `--model-writer-compare-with ducklake`, with clear runtime errors when the feature is not enabled (or when the skeleton is invoked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88071608a2eb2a21f994510c00aceec98aebec20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->