### PR TITLE
feat(model-writer): add validate-compare CLI + Phase 1 SQL parity scripts (v3 E)

### DIFF
--- a/scripts/sql/model-writer-parity/README.md
+++ b/scripts/sql/model-writer-parity/README.md
@@ -1,0 +1,85 @@
+# Model Writer Parity SQL Scripts (v3 Phase E)
+
+Phase 1 canonical raw 表的 SQL 平行校验脚本，配合 `aios-database model-writer` 子命令族做 backend 双写的事后比对。脚本依据 `docs/development/model-writer-storage/07-validation-plan.md` §3 编写，使用 DuckDB 直读 `model_writer_storage/raw/` 下的 JSONL fallback 输出。
+
+## 适用范围
+
+- **Phase 1 表**（13 张）：`raw_inst_info` / `raw_inst_relate` / `raw_inst_geo` / `raw_geo_relate` / `raw_tubi_info` / `raw_tubi_relate` / `raw_neg_relate` / `raw_ngmr_relate` / `raw_aabb` / `raw_trans` / `raw_vec3` / `raw_inst_relate_aabb` / `raw_refno_assoc_index`
+- **Phase 2 不在本目录范围**：`inst_relate_bool` / `inst_relate_cata_bool`（mission 00 §Non-goals + 08 §Phase 5）
+
+## 文件命名约定
+
+```
+<table>_count.sql          # 单边 row count
+<table>_diff.sql           # 双边 key-set diff（LEFT EXCEPT RIGHT + RIGHT EXCEPT LEFT）
+```
+
+13 张表 × 2 个 SQL = **26 个脚本**。
+
+## 输入约定
+
+每个 SQL 脚本通过 DuckDB 的 `read_json_auto()` 读两个目录：
+
+```sql
+-- 在脚本顶部按需替换占位符
+SET VARIABLE LEFT_ROOT = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT = 'project-x';
+SET VARIABLE DBNUM = 1;
+```
+
+每个表的 JSONL 真实路径：
+```
+${LEFT_ROOT}/<table>/project_name=${PROJECT}/dbnum=${DBNUM}/batch_*.jsonl
+```
+
+## 推荐工作流
+
+1. **运行两边 backend**（v3 Phase B + C 已支持）：
+   ```bash
+   # 基线
+   aios-database --model-writer parquet --parquet-output-root output/run-baseline --parquet-dbnum 1 [...]
+   # 候选
+   aios-database --model-writer parquet --parquet-output-root output/run-candidate --parquet-dbnum 1 [...]
+   # 或一次 compare：
+   aios-database --model-writer surreal --model-writer-compare-with parquet \
+                 --parquet-output-root output/run-candidate --parquet-dbnum 1 [...]
+   ```
+
+2. **快速 row-count 比对**（CLI，无需 DuckDB）：
+   ```bash
+   aios-database model-writer diff-summary \
+     --left  output/run-baseline/model_writer_storage/summary/project_name=project-x/dbnum=1/batch_1.json \
+     --right output/run-candidate/model_writer_storage/summary/project_name=project-x/dbnum=1/batch_1.json \
+     --fail-on-diff
+   ```
+
+3. **细粒度 SQL 比对**（本目录脚本）：
+   ```bash
+   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_relate_diff.sql"
+   ```
+
+## DuckDB 安装
+
+```powershell
+# 任选其一：
+choco install duckdb           # Windows + chocolatey
+scoop install duckdb           # Windows + scoop
+brew install duckdb            # macOS
+
+# 或直接下载 https://duckdb.org/docs/installation/
+```
+
+## 限制
+
+- 当前 JSONL fallback 落盘的是 Surreal-json payload 字段，**不是 typed Parquet**。SQL 脚本能跑 row count + key 比对，但 schema 类型断言要等 v4 typed `.parquet` 落地（mission 05 §Phase boundary）。
+- `raw_refno_assoc_index` 标 phase1_limitation：本 PR 仅检查行数存在，不验证 index 字段内容（mission 02 §refno_assoc_index）。
+- mission 03 §Boolean boundary 明确 boolean 表在 Phase 2；本目录不含相关脚本。
+
+## v4 升级路径
+
+当 typed `.parquet` 物化落地后：
+
+1. SQL 脚本里 `read_json_auto()` 换成 `read_parquet()`
+2. 在每个 `_count.sql` 后附加一个 `_schema.sql` 校验列类型
+3. `raw_inst_relate_bool` / `raw_inst_relate_cata_bool` 进入 Phase 2 拓展目录 `scripts/sql/model-writer-parity-phase2/`

--- a/scripts/sql/model-writer-parity/_gen_sql.ps1
+++ b/scripts/sql/model-writer-parity/_gen_sql.ps1
@@ -1,0 +1,112 @@
+# Generator for v3 Phase E SQL parity scripts.
+# Run once to (re-)materialize 26 SQL files (13 tables * 2 each).
+# All generated files are checked into git; this script is for maintenance.
+
+$root = $PSScriptRoot
+
+$tables = @(
+    @{ name = 'raw_inst_info';          keys = @('refno') },
+    @{ name = 'raw_inst_relate';        keys = @('relation_id') },
+    @{ name = 'raw_inst_geo';           keys = @('owner_refno', 'geo_hash') },
+    @{ name = 'raw_geo_relate';         keys = @('relation_id') },
+    @{ name = 'raw_tubi_info';          keys = @('tubi_id') },
+    @{ name = 'raw_tubi_relate';        keys = @('refno', 'branch_id') },
+    @{ name = 'raw_neg_relate';         keys = @('carrier_refno', 'target_refno', 'geom_refno') },
+    @{ name = 'raw_ngmr_relate';        keys = @('carrier_refno', 'target_refno', 'geom_refno') },
+    @{ name = 'raw_aabb';               keys = @('aabb_id') },
+    @{ name = 'raw_trans';              keys = @('trans_id') },
+    @{ name = 'raw_vec3';               keys = @('vec3_id') },
+    @{ name = 'raw_inst_relate_aabb';   keys = @('relation_id') },
+    @{ name = 'raw_refno_assoc_index';  keys = @('refno') }
+)
+
+foreach ($t in $tables) {
+    $name = $t.name
+    $keys = $t.keys
+    $key_csv = $keys -join ', '
+
+    $count_path = Join-Path $root "${name}_count.sql"
+    $count_sql = @"
+-- v3 Phase E: row count for canonical raw table ``$name``.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/${name}_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/${name}/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/${name}/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);
+"@
+    Set-Content -Path $count_path -Value $count_sql -Encoding UTF8 -NoNewline
+
+    $diff_path = Join-Path $root "${name}_diff.sql"
+    $diff_sql = @"
+-- v3 Phase E: key-set diff for canonical raw table ``$name``.
+--
+-- Key columns: $key_csv
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/${name}_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT $key_csv
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/${name}/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT $key_csv
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/${name}/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT $key_csv FROM L
+        EXCEPT
+        SELECT $key_csv FROM R
+    ),
+    only_right AS (
+        SELECT $key_csv FROM R
+        EXCEPT
+        SELECT $key_csv FROM L
+    )
+SELECT 'only_left' AS side, $key_csv FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, $key_csv FROM only_right
+ORDER BY side, $key_csv;
+"@
+    Set-Content -Path $diff_path -Value $diff_sql -Encoding UTF8 -NoNewline
+
+    Write-Host "wrote $count_path"
+    Write-Host "wrote $diff_path"
+}

--- a/scripts/sql/model-writer-parity/raw_aabb_count.sql
+++ b/scripts/sql/model-writer-parity/raw_aabb_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_aabb`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_aabb_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_aabb_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_aabb_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_aabb`.
+--
+-- Key columns: aabb_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_aabb_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT aabb_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT aabb_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT aabb_id FROM L
+        EXCEPT
+        SELECT aabb_id FROM R
+    ),
+    only_right AS (
+        SELECT aabb_id FROM R
+        EXCEPT
+        SELECT aabb_id FROM L
+    )
+SELECT 'only_left' AS side, aabb_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, aabb_id FROM only_right
+ORDER BY side, aabb_id;

--- a/scripts/sql/model-writer-parity/raw_geo_relate_count.sql
+++ b/scripts/sql/model-writer-parity/raw_geo_relate_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_geo_relate`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_geo_relate_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_geo_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_geo_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_geo_relate_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_geo_relate_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_geo_relate`.
+--
+-- Key columns: relation_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_geo_relate_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT relation_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_geo_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT relation_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_geo_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT relation_id FROM L
+        EXCEPT
+        SELECT relation_id FROM R
+    ),
+    only_right AS (
+        SELECT relation_id FROM R
+        EXCEPT
+        SELECT relation_id FROM L
+    )
+SELECT 'only_left' AS side, relation_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, relation_id FROM only_right
+ORDER BY side, relation_id;

--- a/scripts/sql/model-writer-parity/raw_inst_geo_count.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_geo_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_inst_geo`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_geo_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_inst_geo/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_inst_geo/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_inst_geo_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_geo_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_inst_geo`.
+--
+-- Key columns: owner_refno, geo_hash
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_geo_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT owner_refno, geo_hash
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_inst_geo/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT owner_refno, geo_hash
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_inst_geo/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT owner_refno, geo_hash FROM L
+        EXCEPT
+        SELECT owner_refno, geo_hash FROM R
+    ),
+    only_right AS (
+        SELECT owner_refno, geo_hash FROM R
+        EXCEPT
+        SELECT owner_refno, geo_hash FROM L
+    )
+SELECT 'only_left' AS side, owner_refno, geo_hash FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, owner_refno, geo_hash FROM only_right
+ORDER BY side, owner_refno, geo_hash;

--- a/scripts/sql/model-writer-parity/raw_inst_info_count.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_info_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_inst_info`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_info_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_inst_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_inst_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_inst_info_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_info_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_inst_info`.
+--
+-- Key columns: refno
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_info_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT refno
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_inst_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT refno
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_inst_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT refno FROM L
+        EXCEPT
+        SELECT refno FROM R
+    ),
+    only_right AS (
+        SELECT refno FROM R
+        EXCEPT
+        SELECT refno FROM L
+    )
+SELECT 'only_left' AS side, refno FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, refno FROM only_right
+ORDER BY side, refno;

--- a/scripts/sql/model-writer-parity/raw_inst_relate_aabb_count.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_relate_aabb_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_inst_relate_aabb`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_relate_aabb_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_inst_relate_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_inst_relate_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_inst_relate_aabb_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_relate_aabb_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_inst_relate_aabb`.
+--
+-- Key columns: relation_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_relate_aabb_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT relation_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_inst_relate_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT relation_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_inst_relate_aabb/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT relation_id FROM L
+        EXCEPT
+        SELECT relation_id FROM R
+    ),
+    only_right AS (
+        SELECT relation_id FROM R
+        EXCEPT
+        SELECT relation_id FROM L
+    )
+SELECT 'only_left' AS side, relation_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, relation_id FROM only_right
+ORDER BY side, relation_id;

--- a/scripts/sql/model-writer-parity/raw_inst_relate_count.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_relate_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_inst_relate`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_relate_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_inst_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_inst_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_inst_relate_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_inst_relate_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_inst_relate`.
+--
+-- Key columns: relation_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_inst_relate_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT relation_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_inst_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT relation_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_inst_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT relation_id FROM L
+        EXCEPT
+        SELECT relation_id FROM R
+    ),
+    only_right AS (
+        SELECT relation_id FROM R
+        EXCEPT
+        SELECT relation_id FROM L
+    )
+SELECT 'only_left' AS side, relation_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, relation_id FROM only_right
+ORDER BY side, relation_id;

--- a/scripts/sql/model-writer-parity/raw_neg_relate_count.sql
+++ b/scripts/sql/model-writer-parity/raw_neg_relate_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_neg_relate`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_neg_relate_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_neg_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_neg_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_neg_relate_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_neg_relate_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_neg_relate`.
+--
+-- Key columns: carrier_refno, target_refno, geom_refno
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_neg_relate_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT carrier_refno, target_refno, geom_refno
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_neg_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT carrier_refno, target_refno, geom_refno
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_neg_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT carrier_refno, target_refno, geom_refno FROM L
+        EXCEPT
+        SELECT carrier_refno, target_refno, geom_refno FROM R
+    ),
+    only_right AS (
+        SELECT carrier_refno, target_refno, geom_refno FROM R
+        EXCEPT
+        SELECT carrier_refno, target_refno, geom_refno FROM L
+    )
+SELECT 'only_left' AS side, carrier_refno, target_refno, geom_refno FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, carrier_refno, target_refno, geom_refno FROM only_right
+ORDER BY side, carrier_refno, target_refno, geom_refno;

--- a/scripts/sql/model-writer-parity/raw_ngmr_relate_count.sql
+++ b/scripts/sql/model-writer-parity/raw_ngmr_relate_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_ngmr_relate`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_ngmr_relate_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_ngmr_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_ngmr_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_ngmr_relate_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_ngmr_relate_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_ngmr_relate`.
+--
+-- Key columns: carrier_refno, target_refno, geom_refno
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_ngmr_relate_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT carrier_refno, target_refno, geom_refno
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_ngmr_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT carrier_refno, target_refno, geom_refno
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_ngmr_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT carrier_refno, target_refno, geom_refno FROM L
+        EXCEPT
+        SELECT carrier_refno, target_refno, geom_refno FROM R
+    ),
+    only_right AS (
+        SELECT carrier_refno, target_refno, geom_refno FROM R
+        EXCEPT
+        SELECT carrier_refno, target_refno, geom_refno FROM L
+    )
+SELECT 'only_left' AS side, carrier_refno, target_refno, geom_refno FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, carrier_refno, target_refno, geom_refno FROM only_right
+ORDER BY side, carrier_refno, target_refno, geom_refno;

--- a/scripts/sql/model-writer-parity/raw_refno_assoc_index_count.sql
+++ b/scripts/sql/model-writer-parity/raw_refno_assoc_index_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_refno_assoc_index`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_refno_assoc_index_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_refno_assoc_index/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_refno_assoc_index/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_refno_assoc_index_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_refno_assoc_index_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_refno_assoc_index`.
+--
+-- Key columns: refno
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_refno_assoc_index_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT refno
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_refno_assoc_index/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT refno
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_refno_assoc_index/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT refno FROM L
+        EXCEPT
+        SELECT refno FROM R
+    ),
+    only_right AS (
+        SELECT refno FROM R
+        EXCEPT
+        SELECT refno FROM L
+    )
+SELECT 'only_left' AS side, refno FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, refno FROM only_right
+ORDER BY side, refno;

--- a/scripts/sql/model-writer-parity/raw_trans_count.sql
+++ b/scripts/sql/model-writer-parity/raw_trans_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_trans`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_trans_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_trans/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_trans/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_trans_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_trans_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_trans`.
+--
+-- Key columns: trans_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_trans_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT trans_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_trans/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT trans_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_trans/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT trans_id FROM L
+        EXCEPT
+        SELECT trans_id FROM R
+    ),
+    only_right AS (
+        SELECT trans_id FROM R
+        EXCEPT
+        SELECT trans_id FROM L
+    )
+SELECT 'only_left' AS side, trans_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, trans_id FROM only_right
+ORDER BY side, trans_id;

--- a/scripts/sql/model-writer-parity/raw_tubi_info_count.sql
+++ b/scripts/sql/model-writer-parity/raw_tubi_info_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_tubi_info`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_tubi_info_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_tubi_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_tubi_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_tubi_info_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_tubi_info_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_tubi_info`.
+--
+-- Key columns: tubi_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_tubi_info_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT tubi_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_tubi_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT tubi_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_tubi_info/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT tubi_id FROM L
+        EXCEPT
+        SELECT tubi_id FROM R
+    ),
+    only_right AS (
+        SELECT tubi_id FROM R
+        EXCEPT
+        SELECT tubi_id FROM L
+    )
+SELECT 'only_left' AS side, tubi_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, tubi_id FROM only_right
+ORDER BY side, tubi_id;

--- a/scripts/sql/model-writer-parity/raw_tubi_relate_count.sql
+++ b/scripts/sql/model-writer-parity/raw_tubi_relate_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_tubi_relate`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_tubi_relate_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_tubi_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_tubi_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_tubi_relate_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_tubi_relate_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_tubi_relate`.
+--
+-- Key columns: refno, branch_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_tubi_relate_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT refno, branch_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_tubi_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT refno, branch_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_tubi_relate/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT refno, branch_id FROM L
+        EXCEPT
+        SELECT refno, branch_id FROM R
+    ),
+    only_right AS (
+        SELECT refno, branch_id FROM R
+        EXCEPT
+        SELECT refno, branch_id FROM L
+    )
+SELECT 'only_left' AS side, refno, branch_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, refno, branch_id FROM only_right
+ORDER BY side, refno, branch_id;

--- a/scripts/sql/model-writer-parity/raw_vec3_count.sql
+++ b/scripts/sql/model-writer-parity/raw_vec3_count.sql
@@ -1,0 +1,27 @@
+﻿-- v3 Phase E: row count for canonical raw table `raw_vec3`.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_vec3_count.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+SELECT
+    'left'  AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('LEFT_ROOT') || '/raw_vec3/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+)
+UNION ALL
+SELECT
+    'right' AS side,
+    COUNT(*) AS rows
+FROM read_json_auto(
+    getvariable('RIGHT_ROOT') || '/raw_vec3/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+    auto_detect = TRUE,
+    format      = 'newline_delimited'
+);

--- a/scripts/sql/model-writer-parity/raw_vec3_diff.sql
+++ b/scripts/sql/model-writer-parity/raw_vec3_diff.sql
@@ -1,0 +1,45 @@
+﻿-- v3 Phase E: key-set diff for canonical raw table `raw_vec3`.
+--
+-- Key columns: vec3_id
+-- Reports rows present only in LEFT (missing from RIGHT) and only in RIGHT
+-- (extra in RIGHT). Empty result set => parity holds on the key surface.
+--
+-- Usage: replace the four SET VARIABLE placeholders, then run:
+--   duckdb -c ".read scripts/sql/model-writer-parity/raw_vec3_diff.sql"
+
+SET VARIABLE LEFT_ROOT  = 'output/run-baseline/model_writer_storage/raw';
+SET VARIABLE RIGHT_ROOT = 'output/run-candidate/model_writer_storage/raw';
+SET VARIABLE PROJECT    = 'project-x';
+SET VARIABLE DBNUM      = 1;
+
+WITH
+    L AS (
+        SELECT vec3_id
+        FROM read_json_auto(
+            getvariable('LEFT_ROOT') || '/raw_vec3/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    R AS (
+        SELECT vec3_id
+        FROM read_json_auto(
+            getvariable('RIGHT_ROOT') || '/raw_vec3/project_name=' || getvariable('PROJECT') || '/dbnum=' || getvariable('DBNUM') || '/batch_*.jsonl',
+            auto_detect = TRUE,
+            format      = 'newline_delimited'
+        )
+    ),
+    only_left AS (
+        SELECT vec3_id FROM L
+        EXCEPT
+        SELECT vec3_id FROM R
+    ),
+    only_right AS (
+        SELECT vec3_id FROM R
+        EXCEPT
+        SELECT vec3_id FROM L
+    )
+SELECT 'only_left' AS side, vec3_id FROM only_left
+UNION ALL
+SELECT 'only_right' AS side, vec3_id FROM only_right
+ORDER BY side, vec3_id;

--- a/src/cli_modes.rs
+++ b/src/cli_modes.rs
@@ -321,6 +321,162 @@ pub fn validate_canonical_parquet_writer_mode(
     })
 }
 
+// ====================================================================
+//  v3 Phase E: diff-summary — compare two Parquet model-writer summary
+//  JSON files (e.g. primary surreal export vs candidate parquet output,
+//  or two parquet runs across dbnums). Emits a structured JSON report
+//  that downstream SQL parity scripts can cross-reference.
+// ====================================================================
+
+#[derive(Debug, serde::Deserialize)]
+struct SummaryShape {
+    backend: Option<String>,
+    format: Option<String>,
+    project_name: Option<String>,
+    dbnum: Option<u32>,
+    batch_id: Option<u64>,
+    total_rows: Option<usize>,
+    tables: Option<Vec<SummaryTableShape>>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct SummaryTableShape {
+    table: Option<String>,
+    rows: Option<usize>,
+    path: Option<String>,
+    limitation: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SummaryDiffReport {
+    pub status: &'static str,
+    pub left: SummaryDiffSide,
+    pub right: SummaryDiffSide,
+    pub total_rows_diff: i64,
+    pub tables_with_diff: usize,
+    pub tables: Vec<SummaryTableDiff>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SummaryDiffSide {
+    pub path: String,
+    pub backend: Option<String>,
+    pub format: Option<String>,
+    pub project_name: Option<String>,
+    pub dbnum: Option<u32>,
+    pub batch_id: Option<u64>,
+    pub total_rows: Option<usize>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SummaryTableDiff {
+    pub table: String,
+    pub left_rows: Option<usize>,
+    pub right_rows: Option<usize>,
+    pub delta: i64,
+    pub left_path: Option<String>,
+    pub right_path: Option<String>,
+    pub left_limitation: Option<String>,
+    pub right_limitation: Option<String>,
+}
+
+/// Diff two canonical Parquet writer summary JSON files. Both inputs come from
+/// `CanonicalParquetWriter::write_raw_batch` (mission 07 §2a). Designed to be
+/// run from the `model-writer diff-summary` CLI for Phase E parity checks.
+pub fn diff_canonical_parquet_summary(
+    left_path: &Path,
+    right_path: &Path,
+) -> Result<SummaryDiffReport> {
+    let left: SummaryShape = read_summary(left_path)
+        .with_context(|| format!("failed to read --left {}", left_path.display()))?;
+    let right: SummaryShape = read_summary(right_path)
+        .with_context(|| format!("failed to read --right {}", right_path.display()))?;
+
+    let left_total = left.total_rows.unwrap_or(0) as i64;
+    let right_total = right.total_rows.unwrap_or(0) as i64;
+
+    let mut by_table: std::collections::BTreeMap<String, (Option<&SummaryTableShape>, Option<&SummaryTableShape>)> =
+        std::collections::BTreeMap::new();
+    if let Some(rows) = left.tables.as_ref() {
+        for row in rows {
+            if let Some(name) = row.table.as_ref() {
+                by_table.entry(name.clone()).or_insert((None, None)).0 = Some(row);
+            }
+        }
+    }
+    if let Some(rows) = right.tables.as_ref() {
+        for row in rows {
+            if let Some(name) = row.table.as_ref() {
+                by_table.entry(name.clone()).or_insert((None, None)).1 = Some(row);
+            }
+        }
+    }
+
+    let mut tables = Vec::with_capacity(by_table.len());
+    let mut tables_with_diff = 0usize;
+    for (name, (l, r)) in by_table {
+        let left_rows = l.and_then(|t| t.rows);
+        let right_rows = r.and_then(|t| t.rows);
+        let delta = (right_rows.unwrap_or(0) as i64) - (left_rows.unwrap_or(0) as i64);
+        if delta != 0 || left_rows.is_none() != right_rows.is_none() {
+            tables_with_diff += 1;
+        }
+        tables.push(SummaryTableDiff {
+            table: name,
+            left_rows,
+            right_rows,
+            delta,
+            left_path: l.and_then(|t| t.path.clone()),
+            right_path: r.and_then(|t| t.path.clone()),
+            left_limitation: l.and_then(|t| t.limitation.clone()),
+            right_limitation: r.and_then(|t| t.limitation.clone()),
+        });
+    }
+
+    let status = if tables_with_diff == 0 && left_total == right_total {
+        "match"
+    } else {
+        "diff"
+    };
+
+    Ok(SummaryDiffReport {
+        status,
+        left: SummaryDiffSide {
+            path: stable_path_string(left_path),
+            backend: left.backend,
+            format: left.format,
+            project_name: left.project_name,
+            dbnum: left.dbnum,
+            batch_id: left.batch_id,
+            total_rows: left.total_rows,
+        },
+        right: SummaryDiffSide {
+            path: stable_path_string(right_path),
+            backend: right.backend,
+            format: right.format,
+            project_name: right.project_name,
+            dbnum: right.dbnum,
+            batch_id: right.batch_id,
+            total_rows: right.total_rows,
+        },
+        total_rows_diff: right_total - left_total,
+        tables_with_diff,
+        tables,
+    })
+}
+
+fn read_summary(path: &Path) -> Result<SummaryShape> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("read summary file {}", path.display()))?;
+    let parsed: SummaryShape = serde_json::from_str(&content)
+        .with_context(|| format!("parse summary JSON {}", path.display()))?;
+    Ok(parsed)
+}
+
+fn stable_path_string(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
 fn parse_length_unit(unit: &str) -> LengthUnit {
     match unit.to_lowercase().as_str() {
         "mm" => LengthUnit::Millimeter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -791,7 +791,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .subcommand(
             Command::new("model-writer")
-                .about("Model writer storage validation utilities")
+                .about("Model writer storage validation utilities (v3 Phase E)")
                 .subcommand(
                     Command::new("validate-canonical-parquet")
                         .about("Validate CanonicalRawPlanner + CanonicalParquetWriter with an empty ShapeInstancesData fixture")
@@ -825,6 +825,32 @@ async fn main() -> anyhow::Result<()> {
                                 .default_value("1")
                                 .value_parser(clap::value_parser!(u64))
                                 .value_name("ID"),
+                        ),
+                )
+                .subcommand(
+                    Command::new("diff-summary")
+                        .about("v3 Phase E: diff two canonical Parquet writer summary JSON files (table row counts + limitations). Used for compare-mode parity checks without re-running gen-model.")
+                        .arg(
+                            Arg::new("left")
+                                .long("left")
+                                .short('l')
+                                .help("Path to the LEFT summary JSON file (e.g. baseline run)")
+                                .required(true)
+                                .value_name("PATH"),
+                        )
+                        .arg(
+                            Arg::new("right")
+                                .long("right")
+                                .short('r')
+                                .help("Path to the RIGHT summary JSON file (e.g. candidate run)")
+                                .required(true)
+                                .value_name("PATH"),
+                        )
+                        .arg(
+                            Arg::new("fail-on-diff")
+                                .long("fail-on-diff")
+                                .help("Exit with code 2 when status == \"diff\" (default: always exit 0 and print the JSON report)")
+                                .action(clap::ArgAction::SetTrue),
                         ),
                 ),
         )
@@ -1054,6 +1080,23 @@ async fn main() -> anyhow::Result<()> {
                 batch_id,
             )?;
             println!("{}", serde_json::to_string_pretty(&report)?);
+            return Ok(());
+        }
+        if let Some(("diff-summary", sub_matches)) = model_writer_matches.subcommand() {
+            let left = sub_matches
+                .get_one::<String>("left")
+                .map(PathBuf::from)
+                .expect("required by clap");
+            let right = sub_matches
+                .get_one::<String>("right")
+                .map(PathBuf::from)
+                .expect("required by clap");
+            let fail_on_diff = sub_matches.get_flag("fail-on-diff");
+            let report = cli_modes::diff_canonical_parquet_summary(&left, &right)?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            if fail_on_diff && report.status == "diff" {
+                std::process::exit(2);
+            }
             return Ok(());
         }
     }


### PR DESCRIPTION
## Summary

v3 Phase E: lands the **CLI + SQL validation surface** promised by mission `07-validation-plan.md` and the v3 plan §5 Phase E. Two complementary tools:

1. **`aios-database model-writer diff-summary`** — file-level row-count parity check on two `CanonicalParquetBatchSummary` JSON files. Pure Rust, no DuckDB / SurrealDB required.
2. **`scripts/sql/model-writer-parity/*.sql`** — 13 Phase 1 canonical raw tables × 2 (row count + key-set diff) = 26 DuckDB-ready scripts for finer-grained parity checks.

Based on `feat/ducklake-backend-skeleton` (PR #16). Stack:

```
PR #11 (v2 trait + v3 plan)
  └─ PR #14 (Parquet backend)
       └─ PR #15 (Compare wrapper)
            └─ PR #16 (DuckLake skeleton)
                 └─ PR #17 (this) — validation CLI + SQL scripts
```

## Phase E commit slices

| Commit | Scope |
|---|---|
| `023eb327` | E.1 — `diff-summary` CLI subcommand (`cli_modes.rs` + `main.rs`) |
| `10dcba4d` | E.2 — 26 SQL parity scripts + README + maintenance generator |

## E.1 — `diff-summary` CLI

```
aios-database model-writer diff-summary \
  --left  output/run-baseline/model_writer_storage/summary/project_name=p/dbnum=1/batch_1.json \
  --right output/run-candidate/model_writer_storage/summary/project_name=p/dbnum=1/batch_1.json \
  --fail-on-diff
```

Emits structured JSON:

```json
{
  "status": "match" | "diff",
  "left":  { "path": "...", "backend": "...", "total_rows": 0, ... },
  "right": { ... },
  "total_rows_diff": 0,
  "tables_with_diff": 0,
  "tables": [ { "table": "raw_inst_info", "left_rows": 0, "right_rows": 0, "delta": 0, ... }, ... ]
}
```

`--fail-on-diff` flips exit code to 2 when `status == "diff"`, enabling CI gating.

### Smoke results (locally tested)

| Scenario | Status | Exit code |
|---|---|---|
| Two identical baseline runs | `match` | 0 |
| Manually corrupted left summary (5 vs 0 rows in raw_inst_info) | `diff` | 2 |

## E.2 — SQL parity scripts

`scripts/sql/model-writer-parity/`:

| File | Role |
|---|---|
| `README.md` | usage workflow, DuckDB install, Phase 1 vs Phase 2 scope, v4 upgrade path |
| `_gen_sql.ps1` | idempotent generator (re-run after schema changes) |
| `<table>_count.sql` × 13 | row count from LEFT + RIGHT JSONL roots |
| `<table>_diff.sql` × 13 | key-set diff (`EXCEPT` both ways), empty result ⇒ parity holds |

13 Phase 1 tables (mission docs/02-canonical-schema.md §Phase 1):

```
raw_inst_info, raw_inst_relate, raw_inst_geo, raw_geo_relate,
raw_tubi_info, raw_tubi_relate, raw_neg_relate, raw_ngmr_relate,
raw_aabb, raw_trans, raw_vec3, raw_inst_relate_aabb, raw_refno_assoc_index
```

Phase 2 boolean tables (`inst_relate_bool`, `inst_relate_cata_bool`) excluded per mission docs/00 §Non-goals + 08 §Phase 5.

All scripts use `read_json_auto(...)` against the JSONL fallback that `CanonicalParquetWriter` (v3 Phase B) emits. When typed `.parquet` materialization lands in v4, the only required edit is swapping in `read_parquet(...)`.

## Test plan

- [x] `cargo check --bin aios-database --features review` passes
- [x] `diff-summary` on two identical fixtures returns `status: "match"`, exit 0
- [x] `diff-summary` on intentionally diverged fixtures returns `status: "diff"`, exit 2 (with `--fail-on-diff`)
- [x] `validate-canonical-parquet` still works (alias preserved)
- [ ] Reviewer: run any SQL parity script under DuckDB to confirm path layout matches
- [ ] Reviewer (v4 follow-up): swap `read_json_auto` → `read_parquet` once typed parquet lands

## Architecture invariants honored

1. DrainOnly / Surreal / Parquet / Compare / DuckLake backends untouched
2. No new crate dependencies (diff-summary uses serde_json already pulled in)
3. `[model-writer:*]` log prefix preserved (Phase E only emits structured JSON on stdout)
4. SQL scripts are independent of `cargo test` (mission 07 §Rule honored: no Rust tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive validation tooling (new CLI subcommand + offline SQL scripts) and do not alter model-writer storage/write paths.
> 
> **Overview**
> Adds `aios-database model-writer diff-summary`, which diffs two canonical Parquet writer summary JSON files and emits a structured report (with optional `--fail-on-diff` to exit non-zero when row counts differ).
> 
> Introduces `scripts/sql/model-writer-parity/` with a README, a maintenance generator (`_gen_sql.ps1`), and 26 DuckDB SQL scripts (13 Phase 1 raw tables × `*_count.sql` + `*_diff.sql`) to compare LEFT/RIGHT JSONL fallback outputs via row counts and key-set `EXCEPT` diffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10dcba4d95ee4173c0774de39339ca720fffc984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->