### PR TITLE
refactor(model-writer): drop BooleanBridgeRequest::db_option via cached context (v3 F.2)

### DIFF
--- a/src/bin/verify_model_writer_trait.rs
+++ b/src/bin/verify_model_writer_trait.rs
@@ -57,6 +57,7 @@ async fn main() -> ExitCode {
         use_surrealdb: true,
         defer_db_write: false,
         mode: ModelWriterMode::Surreal,
+        db_option: Arc::new(aios_core::options::DbOption::default()),
     };
 
     let shape_insts = ShapeInstancesData::default();
@@ -183,7 +184,6 @@ async fn main() -> ExitCode {
     if let Err(e) = backend
         .run_boolean_bridge(BooleanBridgeRequest {
             mode: BooleanPipelineMode::DbLegacy,
-            db_option: Arc::new(aios_core::options::DbOption::default()),
             bool_tasks: Vec::new(),
         })
         .await
@@ -287,6 +287,7 @@ async fn main() -> ExitCode {
         use_surrealdb: false,
         defer_db_write: false,
         mode: ModelWriterMode::Parquet,
+        db_option: Arc::new(aios_core::options::DbOption::default()),
     };
 
     if let Err(e) = parquet_backend.init(&parquet_ctx).await {
@@ -371,7 +372,6 @@ async fn main() -> ExitCode {
     let parquet_bool_report = match parquet_backend
         .run_boolean_bridge(BooleanBridgeRequest {
             mode: BooleanPipelineMode::DbLegacy,
-            db_option: Arc::new(aios_core::options::DbOption::default()),
             bool_tasks: Vec::new(),
         })
         .await
@@ -455,6 +455,7 @@ async fn main() -> ExitCode {
         use_surrealdb: false,
         defer_db_write: false,
         mode: ModelWriterMode::Parquet,
+        db_option: Arc::new(aios_core::options::DbOption::default()),
     };
     if compare_wrapper.name() != "compare" {
         eprintln!(
@@ -529,7 +530,6 @@ async fn main() -> ExitCode {
     if let Err(e) = compare_wrapper
         .run_boolean_bridge(BooleanBridgeRequest {
             mode: BooleanPipelineMode::DbLegacy,
-            db_option: Arc::new(aios_core::options::DbOption::default()),
             bool_tasks: Vec::new(),
         })
         .await

--- a/src/fast_model/gen_model/model_writer/mod.rs
+++ b/src/fast_model/gen_model/model_writer/mod.rs
@@ -46,6 +46,11 @@ pub struct ModelWriterContext {
     pub use_surrealdb: bool,
     pub defer_db_write: bool,
     pub mode: ModelWriterMode,
+    /// v3 Phase F.2: the underlying `DbOption` is now cached on init so
+    /// `BooleanBridgeRequest` no longer has to ship it on every call.
+    /// Backends that need a `DbOption` (currently only Surreal's boolean
+    /// worker) pull it from the context they cached during `init`.
+    pub db_option: Arc<aios_core::options::DbOption>,
 }
 
 impl ModelWriterContext {
@@ -55,6 +60,7 @@ impl ModelWriterContext {
             use_surrealdb: db_option.use_surrealdb,
             defer_db_write: db_option.defer_db_write,
             mode: db_option.model_writer_mode,
+            db_option: Arc::new(db_option.inner.clone()),
         }
     }
 }
@@ -95,11 +101,12 @@ pub struct ReconcileRequest<'a> {
 
 pub struct BooleanBridgeRequest {
     pub mode: BooleanPipelineMode,
-    // TODO(P5): replace with a minimal BridgeContext to remove DbOption coupling
-    // from the trait surface. See findings.md §3 (decision: keep short-term).
-    pub db_option: Arc<aios_core::options::DbOption>,
     pub bool_tasks: Vec<BooleanTask>,
 }
+
+// v3 Phase F.2 (completed): the previous `db_option: Arc<DbOption>` field has
+// been removed. Backends that need a `DbOption` for the boolean worker pull it
+// from `ModelWriterContext::db_option` cached during `init`.
 
 #[derive(Debug, Clone)]
 pub struct BooleanBridgeReport {

--- a/src/fast_model/gen_model/model_writer/surreal.rs
+++ b/src/fast_model/gen_model/model_writer/surreal.rs
@@ -239,11 +239,14 @@ impl ModelWriterBackend for SurrealModelWriterBackend {
                 "init not called before run_boolean_bridge",
             ));
         };
+        // v3 Phase F.2: db_option pulled from cached context (was an
+        // explicit field on BooleanBridgeRequest before).
+        let db_option = ctx.db_option.clone();
         match request.mode {
             BooleanPipelineMode::DbLegacy => {
                 if ctx.use_surrealdb && !ctx.defer_db_write {
                     println!("[model-writer:surreal] stage=boolean_bridge pipeline=db_legacy");
-                    run_boolean_worker(request.db_option, 100)
+                    run_boolean_worker(db_option, 100)
                         .await
                         .context("model_writer surreal db_legacy boolean bridge failed")?;
                     Ok(BooleanBridgeReport::db_legacy_executed())
@@ -267,10 +270,9 @@ impl ModelWriterBackend for SurrealModelWriterBackend {
                     "[model-writer:surreal] stage=boolean_bridge pipeline=memory_tasks total_tasks={}",
                     request.bool_tasks.len()
                 );
-                let report =
-                    run_bool_worker_from_tasks(request.bool_tasks, request.db_option, None)
-                        .await
-                        .context("model_writer surreal memory_tasks boolean bridge failed")?;
+                let report = run_bool_worker_from_tasks(request.bool_tasks, db_option, None)
+                    .await
+                    .context("model_writer surreal memory_tasks boolean bridge failed")?;
                 Ok(report.into())
             }
         }

--- a/src/fast_model/gen_model/orchestrator.rs
+++ b/src/fast_model/gen_model/orchestrator.rs
@@ -1440,7 +1440,6 @@ async fn process_index_tree_generation(
                     let report = model_writer
                         .run_boolean_bridge(BooleanBridgeRequest {
                             mode: BooleanPipelineMode::DbLegacy,
-                            db_option: Arc::new(db_option.inner.clone()),
                             bool_tasks: Vec::new(),
                         })
                         .await
@@ -1489,7 +1488,6 @@ async fn process_index_tree_generation(
                         let report = model_writer
                             .run_boolean_bridge(BooleanBridgeRequest {
                                 mode: BooleanPipelineMode::MemoryTasks,
-                                db_option: Arc::new(db_option.inner.clone()),
                                 bool_tasks: std::mem::take(&mut bool_tasks),
                             })
                             .await


### PR DESCRIPTION
## Summary

v3 Phase F.2: closes the last `Arc<DbOption>` exposure on the `ModelWriterBackend` trait surface. `BooleanBridgeRequest` is now down to 2 fields (`mode` + `bool_tasks`); backends that need a `DbOption` pull it from `ModelWriterContext::db_option` cached during `init`.

Based on `refactor/take-missing-neg-carriers` (PR #18). Final stack:

```
PR #11 → PR #14 → PR #15 → PR #16 → PR #17 → PR #18 → PR #19 (this)
```

## What changed

**`ModelWriterContext` (v3 P3 already cached this for OnceLock use)**

```diff
 pub struct ModelWriterContext {
     pub project_name: String,
     pub use_surrealdb: bool,
     pub defer_db_write: bool,
     pub mode: ModelWriterMode,
+    pub db_option: Arc<aios_core::options::DbOption>,
 }
```

`from_db_option(db_option_ext)` auto-populates the field, so callsites do not change.

**`BooleanBridgeRequest`**

```diff
 pub struct BooleanBridgeRequest {
     pub mode: BooleanPipelineMode,
-    pub db_option: Arc<aios_core::options::DbOption>,
     pub bool_tasks: Vec<BooleanTask>,
 }
```

**SurrealModelWriterBackend**

```diff
-run_boolean_worker(request.db_option, 100)
+let db_option = ctx.db_option.clone();   // from cached context
+run_boolean_worker(db_option, 100)
```

**Orchestrator**

Two `run_boolean_bridge(BooleanBridgeRequest { ..., db_option: Arc::new(db_option.inner.clone()), ... })` callsites simplify to drop the `db_option` field. No semantic change.

**Verify binary**

Three `ModelWriterContext` fixtures now also fill `db_option: Arc::new(DbOption::default())`.

## Test plan

- [x] `cargo check --bin aios-database --features review` passes
- [x] `cargo run --bin verify_model_writer_trait --features model-writer-mock` → PASS
  - Mock snapshot still 11 entries (F.1's take_missing_neg flow unchanged)
  - Parquet end-to-end 13 tables + summary JSON
  - Compare wrapper end-to-end with both backends drained

## Architecture invariants honored

1. Trait method **signatures** unchanged (only the `BooleanBridgeRequest` struct shrank by one field)
2. DrainOnly / Parquet / DuckLake / Mock / Compare backends untouched (none ever read `db_option` from the request)
3. SurrealDB write semantics preserved (`run_boolean_worker` / `run_bool_worker_from_tasks` see the same `Arc<DbOption>`, just via a different plumbing path)
4. No new crate dependencies
5. `[model-writer:*]` log prefix preserved
6. `findings.md` §3 decision on "BridgeContext extraction → P5 backlog" is now resolved by **caching on init** instead of introducing a separate `BridgeContext` type — simpler and matches the v3 P3 OnceLock pattern already in place

## Commits

| Commit | Scope |
|---|---|
| `738c31b2` | F.2 — `ModelWriterContext.db_option` + remove `BooleanBridgeRequest.db_option` + Surreal/orchestrator/verify updates |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `DbOption` is plumbed through the model-writer boolean bridge (trait request shape + Surreal boolean execution), which could break boolean runs if context init/caching is wrong.
> 
> **Overview**
> **Removes `DbOption` from the `ModelWriterBackend` boolean-bridge call surface** by dropping `BooleanBridgeRequest::db_option` and instead caching an `Arc<DbOption>` on `ModelWriterContext` during `init`.
> 
> Updates Surreal’s `run_boolean_bridge` implementation to read `db_option` from the cached context, and adjusts orchestrator + `verify_model_writer_trait` fixtures/callsites to stop passing `db_option` per request and to populate `ModelWriterContext::db_option`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738c31b23812ef81a43c02c2775286034ba2f0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->