### PR TITLE
refactor(model-writer): DrainOnly trait stats — Mutex → atomic (v4 §2.3)

### DIFF
--- a/src/fast_model/gen_model/model_writer/drain_only.rs
+++ b/src/fast_model/gen_model/model_writer/drain_only.rs
@@ -13,7 +13,8 @@
 //! these six methods without re-validating that the baseline IO-skip semantic
 //! is preserved (see `orchestrator.rs` `DrainOnly` fast-path comment).
 
-use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use aios_core::geometry::ShapeInstancesData;
@@ -104,19 +105,83 @@ pub async fn run_drain_only_sink(
     Ok(stats)
 }
 
-#[derive(Debug)]
-pub struct DrainOnlyModelWriterBackend {
-    stats: Mutex<DrainOnlyStats>,
-    started: Mutex<Option<Instant>>,
+/// Lock-free DrainOnly stats accumulator for the trait-routed path
+/// (mock/verify binary, NOT the production fast-path).
+///
+/// v4 §2.3: replaces the previous `Mutex<DrainOnlyStats>` with independent
+/// `AtomicU64` counters. The architectural invariant is unchanged
+/// (production orchestrator skips the middle 6 trait methods entirely;
+/// `run_drain_only_sink` still owns a stack-allocated `DrainOnlyStats`
+/// with no atomic overhead). This struct only matters when something
+/// _does_ drive the trait — primarily the verify binary asserting that
+/// `add_batch` counters fire as expected.
+#[derive(Debug, Default)]
+struct DrainOnlyAtomicStats {
+    batches: AtomicU64,
+    instances: AtomicU64,
+    inst_info: AtomicU64,
+    inst_tubi: AtomicU64,
+    geo_keys: AtomicU64,
+    geo_instances: AtomicU64,
+    neg_relations: AtomicU64,
+    ngmr_relations: AtomicU64,
+    mesh_result_batches: AtomicU64,
+    mesh_results: AtomicU64,
+    inst_relate_aabb_batches: AtomicU64,
 }
 
-impl Default for DrainOnlyModelWriterBackend {
-    fn default() -> Self {
-        Self {
-            stats: Mutex::new(DrainOnlyStats::default()),
-            started: Mutex::new(None),
+impl DrainOnlyAtomicStats {
+    fn add_batch(&self, batch: &ShapeInstancesData) {
+        self.batches.fetch_add(1, Ordering::Relaxed);
+        self.instances
+            .fetch_add(batch.inst_cnt() as u64, Ordering::Relaxed);
+        self.inst_info
+            .fetch_add(batch.inst_info_map.len() as u64, Ordering::Relaxed);
+        self.inst_tubi
+            .fetch_add(batch.inst_tubi_map.len() as u64, Ordering::Relaxed);
+        self.geo_keys
+            .fetch_add(batch.inst_geos_map.len() as u64, Ordering::Relaxed);
+        let geo_instances: usize = batch
+            .inst_geos_map
+            .values()
+            .map(|geos| geos.insts.len())
+            .sum();
+        self.geo_instances
+            .fetch_add(geo_instances as u64, Ordering::Relaxed);
+        let neg: usize = batch.neg_relate_map.values().map(Vec::len).sum();
+        self.neg_relations
+            .fetch_add(neg as u64, Ordering::Relaxed);
+        let ngmr: usize = batch.ngmr_neg_relate_map.values().map(Vec::len).sum();
+        self.ngmr_relations
+            .fetch_add(ngmr as u64, Ordering::Relaxed);
+    }
+
+    /// Atomic snapshot into a regular `DrainOnlyStats` so we can reuse the
+    /// canonical `print_summary` format.
+    fn snapshot(&self, elapsed: Duration) -> DrainOnlyStats {
+        DrainOnlyStats {
+            batches: self.batches.load(Ordering::Relaxed) as usize,
+            instances: self.instances.load(Ordering::Relaxed) as usize,
+            inst_info: self.inst_info.load(Ordering::Relaxed) as usize,
+            inst_tubi: self.inst_tubi.load(Ordering::Relaxed) as usize,
+            geo_keys: self.geo_keys.load(Ordering::Relaxed) as usize,
+            geo_instances: self.geo_instances.load(Ordering::Relaxed) as usize,
+            neg_relations: self.neg_relations.load(Ordering::Relaxed) as usize,
+            ngmr_relations: self.ngmr_relations.load(Ordering::Relaxed) as usize,
+            mesh_result_batches: self.mesh_result_batches.load(Ordering::Relaxed) as usize,
+            mesh_results: self.mesh_results.load(Ordering::Relaxed) as usize,
+            inst_relate_aabb_batches: self
+                .inst_relate_aabb_batches
+                .load(Ordering::Relaxed) as usize,
+            elapsed,
         }
     }
+}
+
+#[derive(Debug, Default)]
+pub struct DrainOnlyModelWriterBackend {
+    stats: DrainOnlyAtomicStats,
+    started: OnceLock<Instant>,
 }
 
 #[async_trait]
@@ -133,7 +198,9 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
             context.defer_db_write,
             context.mode.as_str()
         );
-        *self.started.lock().expect("drain-only started lock") = Some(Instant::now());
+        // Second init keeps the original Instant (OnceLock is set-once); this
+        // preserves the v3 verify-binary "second init is safe" assertion.
+        let _ = self.started.set(Instant::now());
         Ok(())
     }
 
@@ -154,10 +221,7 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
     ) -> anyhow::Result<WriteBaseReport> {
         // architectural-invariant: not called by orchestrator main pipeline
         // when ModelWriterMode::DrainOnly is selected (baseline fast path).
-        {
-            let mut stats = self.stats.lock().expect("drain-only stats lock");
-            stats.add_batch(batch.shape_insts);
-        }
+        self.stats.add_batch(batch.shape_insts);
         println!(
             "[model-writer:drain-only] stage=base batch={} inst_info={} inst_tubi={} geo_keys={}",
             batch.batch_id,
@@ -175,11 +239,12 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
         // architectural-invariant: not called by orchestrator main pipeline
         // when ModelWriterMode::DrainOnly is selected (baseline fast path).
         let count = batch.mesh_results.len();
-        {
-            let mut stats = self.stats.lock().expect("drain-only stats lock");
-            stats.mesh_result_batches += 1;
-            stats.mesh_results += count;
-        }
+        self.stats
+            .mesh_result_batches
+            .fetch_add(1, Ordering::Relaxed);
+        self.stats
+            .mesh_results
+            .fetch_add(count as u64, Ordering::Relaxed);
         println!(
             "[model-writer:drain-only] stage=mesh_results batch={} mesh_results={}",
             batch.batch_id, count
@@ -190,10 +255,9 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
     async fn write_inst_relate_aabb(&self, batch: InstRelateAabbBatch<'_>) -> anyhow::Result<()> {
         // architectural-invariant: not called by orchestrator main pipeline
         // when ModelWriterMode::DrainOnly is selected (baseline fast path).
-        {
-            let mut stats = self.stats.lock().expect("drain-only stats lock");
-            stats.inst_relate_aabb_batches += 1;
-        }
+        self.stats
+            .inst_relate_aabb_batches
+            .fetch_add(1, Ordering::Relaxed);
         println!(
             "[model-writer:drain-only] stage=inst_relate_aabb batch={} mesh_results={} aabb_keys={}",
             batch.batch_id,
@@ -235,15 +299,11 @@ impl ModelWriterBackend for DrainOnlyModelWriterBackend {
     async fn finalize(&self, request: FinalizeRequest) -> anyhow::Result<FinalizeSummary> {
         let elapsed = self
             .started
-            .lock()
-            .expect("drain-only started lock")
+            .get()
             .map(|t| t.elapsed())
             .unwrap_or_default();
-        {
-            let mut stats = self.stats.lock().expect("drain-only stats lock");
-            stats.elapsed = elapsed;
-            stats.print_summary();
-        }
+        let snapshot = self.stats.snapshot(elapsed);
+        snapshot.print_summary();
         println!(
             "[model-writer:drain-only] stage=finalize total_batches={} completed_batches={} mesh_cache_hits={} mesh_new_generated={} missing_neg_candidates={}",
             request.total_batches,


### PR DESCRIPTION
## Summary

**First v4 follow-up PR**. Closes v4 §2.3 from `v4-candidates.md`: replaces the `Mutex<DrainOnlyStats>` accumulator inside `DrainOnlyModelWriterBackend` with independent `AtomicU64` counters. Production DrainOnly fast-path semantics untouched.

Based on `refactor/bridge-context` (PR #19, last v3 PR). Final stack:

```
PR #11 → PR #14 → PR #15 → PR #16 → PR #17 → PR #18 → PR #19 → PR #20 (this, first v4)
```

## What changed

Single file: `src/fast_model/gen_model/model_writer/drain_only.rs` (~90 net lines)

| Before | After |
|---|---|
| `stats: Mutex<DrainOnlyStats>` | `stats: DrainOnlyAtomicStats` (private, 11×`AtomicU64`) |
| `started: Mutex<Option<Instant>>` | `started: OnceLock<Instant>` |
| `stats.lock().unwrap().add_batch(...)` | `self.stats.add_batch(...)` (`fetch_add` under the hood) |
| `stats.lock().unwrap().mesh_results += count` | `self.stats.mesh_results.fetch_add(count as u64, Relaxed)` |
| `stats.lock().unwrap().print_summary()` | `self.stats.snapshot(elapsed).print_summary()` |
| `*started.lock().unwrap() = Some(Instant::now())` | `self.started.set(Instant::now())` (set-once) |

`DrainOnlyAtomicStats::snapshot(elapsed) -> DrainOnlyStats` lets us keep the canonical `print_summary` byte-identical (and the public `DrainOnlyStats` struct exported by the module is unchanged).

## Architecture invariants preserved (v3 + v4 §0)

1. **DrainOnly fast path (`run_drain_only_sink`) untouched** — still uses stack-allocated `DrainOnlyStats` with plain `usize` += and zero atomic overhead. Baseline IO-skip semantic intact.
2. The middle 6 trait methods are still defensive scaffolding, not routed by production orchestrator.
3. No public API surface change — `DrainOnlyAtomicStats` is `pub(self)`-only.
4. "Second init is safe" assertion (v3 verify binary, exit code 5) preserved by switching from `Mutex<Option<Instant>>` to `OnceLock<Instant>` (set-once semantics).

## Test plan

- [x] `cargo check --bin aios-database --features review` passes
- [x] `cargo run --bin verify_model_writer_trait --features model-writer-mock` → PASS
  - Mock 11 snapshot entries unchanged
  - Parquet 13 canonical raw tables + summary JSON
  - Compare wrapper end-to-end (both backends drained)
- [x] DrainOnly trait-routed path: all 4 atomic counters increment correctly (verified via verify binary)
- [ ] Reviewer: ack that `Ordering::Relaxed` is sufficient (stats observed once at finalize, no inter-thread ordering needed)
- [ ] Reviewer: ack that `OnceLock<Instant>` preserves v3 "second init is safe" semantics (set-once → second call is a no-op, no panic)

## Why this PR exists

`v4-candidates.md` §2.3 was tagged "small PR, lowest risk" — chosen as the first v4 increment to validate the v4 stack-on-PR-#19 pattern works before tackling the larger v4 items (typed Parquet, DuckLake real, async fn in trait research, Phase 2 boolean).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `DrainOnlyModelWriterBackend`’s internal stats tracking and init timing; behavior should be unchanged aside from concurrency characteristics, with minor risk of incorrect counters or elapsed time if atomic/OnceLock usage is wrong.
> 
> **Overview**
> Refactors the `DrainOnlyModelWriterBackend` trait-routed stats collection to be lock-free by replacing the internal `Mutex<DrainOnlyStats>` accumulator with a private `DrainOnlyAtomicStats` that uses `AtomicU64` counters (`Ordering::Relaxed`).
> 
> Switches `started` tracking from `Mutex<Option<Instant>>` to `OnceLock<Instant>` (keeping “second init is safe” semantics), and updates `finalize` to snapshot atomics into a `DrainOnlyStats` for unchanged summary printing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be005740e68e50803febb94a2e1407394e75b69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->